### PR TITLE
update gateway.util to conform to code.quality standards

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
         <url>git@github.com:kaazing/gateway.util.git</url>
     </scm>
 
+    <properties>
+        <checkstyle.config.location>org/kaazing/code/quality/checkstyle.xml</checkstyle.config.location>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -58,5 +62,39 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.11</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <encoding>UTF-8</encoding>
+                            <!-- checkstyle doesn't like lambdas and·
+                                 exceptions and bails -->
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                            <failOnViolation>true</failOnViolation>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.kaazing</groupId>
+                        <artifactId>code.quality</artifactId>
+                        <version>1.1</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/java/org/kaazing/gateway/util/AtomicCounter.java
+++ b/src/main/java/org/kaazing/gateway/util/AtomicCounter.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/main/java/org/kaazing/gateway/util/ConsumeToTerminatorDecodingState.java
+++ b/src/main/java/org/kaazing/gateway/util/ConsumeToTerminatorDecodingState.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,12 +25,13 @@ import org.apache.mina.filter.codec.ProtocolDecoderOutput;
 import org.apache.mina.filter.codec.statemachine.DecodingState;
 import org.kaazing.mina.core.buffer.IoBufferAllocatorEx;
 
-public abstract class ConsumeToTerminatorDecodingState extends org.kaazing.mina.filter.codec.statemachine.ConsumeToTerminatorDecodingState {
+public abstract class ConsumeToTerminatorDecodingState
+        extends org.kaazing.mina.filter.codec.statemachine.ConsumeToTerminatorDecodingState {
 
     public ConsumeToTerminatorDecodingState(IoBufferAllocatorEx<?> allocator, byte terminator) {
         super(allocator, terminator);
     }
-    
+
     @Override
     public DecodingState finishDecode(ProtocolDecoderOutput out) throws Exception {
         return this;

--- a/src/main/java/org/kaazing/gateway/util/DecodingState.java
+++ b/src/main/java/org/kaazing/gateway/util/DecodingState.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,20 +22,21 @@
 package org.kaazing.gateway.util;
 
 /**
- * This is used by Encoder to hold a "stray" byte that is not yet UTF-8 decode-able. It is prepended onto the next message to form a
+ * This is used by Encoder to hold a "stray" byte that is not yet UTF-8 decode-able.
+ * It is prepended onto the next message to form a
  * valid (possibly escaped) UTF-8 byte sequence.
- * This is needed to handle case where a UTF8 character or escaped UTF8 character is 
+ * This is needed to handle case where a UTF8 character or escaped UTF8 character is
  * represented as 2 bytes and gets split between packets.  See KG-3124 for a situation where this
  * makes a difference, and KG-4013 to note that this is important to get
  * right for all sorts of UTF-8 buffers, and KG-4372.
  */
 public interface DecodingState {
 
-    public Object get();
+    Object get();
 
-    public void set(Object state);
-    
-    public static final DecodingState NONE = new DecodingState() {
+    void set(Object state);
+
+    DecodingState NONE = new DecodingState() {
         @Override
         public Object get() {
             return null;
@@ -47,5 +48,5 @@ public interface DecodingState {
             }
         }
     };
-    
+
 }

--- a/src/main/java/org/kaazing/gateway/util/Encoding.java
+++ b/src/main/java/org/kaazing/gateway/util/Encoding.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,227 +25,227 @@ import java.nio.ByteBuffer;
 
 public enum Encoding {
 
-	TEXT {
-		public ByteBuffer encode(ByteBuffer buf) {
-			return buf;
-		}
+    TEXT {
+        public ByteBuffer encode(ByteBuffer buf) {
+            return buf;
+        }
 
-		public ByteBuffer decode(ByteBuffer buf, DecodingState state) {
-			return buf;
-		}
-	},
-	BINARY {
-		public ByteBuffer encode(ByteBuffer buf) {
-			return buf;
-		}
+        public ByteBuffer decode(ByteBuffer buf, DecodingState state) {
+            return buf;
+        }
+    },
+    BINARY {
+        public ByteBuffer encode(ByteBuffer buf) {
+            return buf;
+        }
 
-		public ByteBuffer decode(ByteBuffer buf, DecodingState state) {
-			return buf;
-		}
-	},
-	BASE64 {
-		public ByteBuffer encode(ByteBuffer decoded) {
-			if (decoded.hasArray()) {
-				return encodeWithHeap(decoded);
-			}
-			else {
-				return encodeWithDirect(decoded);
-			}
-		}
-		
-		private ByteBuffer encodeWithDirect(ByteBuffer decoded) {
-			final int decodedSize = decoded.remaining();
-			final int effectiveDecodedSize = (int) Math.ceil(decodedSize / 3.0f) * 3;
-			final int decodedFragmentSize = (3 - (effectiveDecodedSize - decodedSize)) % 3;
+        public ByteBuffer decode(ByteBuffer buf, DecodingState state) {
+            return buf;
+        }
+    },
+    BASE64 {
+        public ByteBuffer encode(ByteBuffer decoded) {
+            if (decoded.hasArray()) {
+                return encodeWithHeap(decoded);
+            }
+            else {
+                return encodeWithDirect(decoded);
+            }
+        }
 
-			final int encodedArraySize = effectiveDecodedSize / 3 * 4;
-			final byte[] encodedArray = new byte[encodedArraySize];
-			int encodedArrayPosition = 0;
+        private ByteBuffer encodeWithDirect(ByteBuffer decoded) {
+            final int decodedSize = decoded.remaining();
+            final int effectiveDecodedSize = (int) Math.ceil(decodedSize / 3.0f) * 3;
+            final int decodedFragmentSize = (3 - (effectiveDecodedSize - decodedSize)) % 3;
 
-			int decodedArrayPosition = decoded.position();
-			final int decodedArrayLimit = decoded.limit() - decodedFragmentSize;
+            final int encodedArraySize = effectiveDecodedSize / 3 * 4;
+            final byte[] encodedArray = new byte[encodedArraySize];
+            int encodedArrayPosition = 0;
 
-			while (decodedArrayPosition < decodedArrayLimit) {
-				int byte0 = decoded.get(decodedArrayPosition++) & 0xff;
-				int byte1 = decoded.get(decodedArrayPosition++) & 0xff;
-				int byte2 = decoded.get(decodedArrayPosition++) & 0xff;
+            int decodedArrayPosition = decoded.position();
+            final int decodedArrayLimit = decoded.limit() - decodedFragmentSize;
 
-				encodedArray[encodedArrayPosition++] = INDEXED[(byte0 >> 2) & 0x3f];
-				encodedArray[encodedArrayPosition++] = INDEXED[((byte0 << 4) & 0x30)
-						| ((byte1 >> 4) & 0x0f)];
-				encodedArray[encodedArrayPosition++] = INDEXED[((byte1 << 2) & 0x3c)
-						| ((byte2 >> 6) & 0x03)];
-				encodedArray[encodedArrayPosition++] = INDEXED[byte2 & 0x3f];
-			}
+            while (decodedArrayPosition < decodedArrayLimit) {
+                int byte0 = decoded.get(decodedArrayPosition++) & 0xff;
+                int byte1 = decoded.get(decodedArrayPosition++) & 0xff;
+                int byte2 = decoded.get(decodedArrayPosition++) & 0xff;
 
-			switch (decodedFragmentSize) {
-			case 0:
-				break;
-			case 1: {
-				int byte0 = decoded.get(decodedArrayPosition++) & 0xff;
+                encodedArray[encodedArrayPosition++] = INDEXED[(byte0 >> 2) & 0x3f];
+                encodedArray[encodedArrayPosition++] = INDEXED[((byte0 << 4) & 0x30)
+                        | ((byte1 >> 4) & 0x0f)];
+                encodedArray[encodedArrayPosition++] = INDEXED[((byte1 << 2) & 0x3c)
+                        | ((byte2 >> 6) & 0x03)];
+                encodedArray[encodedArrayPosition++] = INDEXED[byte2 & 0x3f];
+            }
 
-				encodedArray[encodedArrayPosition++] = INDEXED[(byte0 >> 2) & 0x3f];
-				encodedArray[encodedArrayPosition++] = INDEXED[((byte0 << 4) & 0x30)];
-				encodedArray[encodedArrayPosition++] = PADDING_BYTE;
-				encodedArray[encodedArrayPosition++] = PADDING_BYTE;
-				break;
-			}
-			case 2: {
-				int byte0 = decoded.get(decodedArrayPosition++) & 0xff;
-				int byte1 = decoded.get(decodedArrayPosition++) & 0xff;
+            switch (decodedFragmentSize) {
+            case 0:
+                break;
+            case 1: {
+                int byte0 = decoded.get(decodedArrayPosition++) & 0xff;
 
-				encodedArray[encodedArrayPosition++] = INDEXED[(byte0 >> 2) & 0x3f];
-				encodedArray[encodedArrayPosition++] = INDEXED[((byte0 << 4) & 0x30)
-						| ((byte1 >> 4) & 0x0f)];
-				encodedArray[encodedArrayPosition++] = INDEXED[(byte1 << 2) & 0x3c];
-				encodedArray[encodedArrayPosition++] = PADDING_BYTE;
-				break;
-			}
-			default: {
-				throw new IllegalArgumentException("Invalid base64 encoding");
-			}
-			}
+                encodedArray[encodedArrayPosition++] = INDEXED[(byte0 >> 2) & 0x3f];
+                encodedArray[encodedArrayPosition++] = INDEXED[(byte0 << 4) & 0x30];
+                encodedArray[encodedArrayPosition++] = PADDING_BYTE;
+                encodedArray[encodedArrayPosition++] = PADDING_BYTE;
+                break;
+            }
+            case 2: {
+                int byte0 = decoded.get(decodedArrayPosition++) & 0xff;
+                int byte1 = decoded.get(decodedArrayPosition++) & 0xff;
 
-			return ByteBuffer.wrap(encodedArray);
-		}
+                encodedArray[encodedArrayPosition++] = INDEXED[(byte0 >> 2) & 0x3f];
+                encodedArray[encodedArrayPosition++] = INDEXED[((byte0 << 4) & 0x30)
+                        | ((byte1 >> 4) & 0x0f)];
+                encodedArray[encodedArrayPosition++] = INDEXED[(byte1 << 2) & 0x3c];
+                encodedArray[encodedArrayPosition++] = PADDING_BYTE;
+                break;
+            }
+            default: {
+                throw new IllegalArgumentException("Invalid base64 encoding");
+            }
+            }
 
-		private ByteBuffer encodeWithHeap(ByteBuffer decoded) {
-			final int decodedSize = decoded.remaining();
-			final int effectiveDecodedSize = (int) Math.ceil(decodedSize / 3.0f) * 3;
-			final int decodedFragmentSize = (3 - (effectiveDecodedSize - decodedSize)) % 3;
+            return ByteBuffer.wrap(encodedArray);
+        }
 
-			final int encodedArraySize = effectiveDecodedSize / 3 * 4;
-			final byte[] encodedArray = new byte[encodedArraySize];
-			int encodedArrayPosition = 0;
+        private ByteBuffer encodeWithHeap(ByteBuffer decoded) {
+            final int decodedSize = decoded.remaining();
+            final int effectiveDecodedSize = (int) Math.ceil(decodedSize / 3.0f) * 3;
+            final int decodedFragmentSize = (3 - (effectiveDecodedSize - decodedSize)) % 3;
 
-			final byte[] decodedArray = decoded.array();
-			final int decodedArrayOffset = decoded.arrayOffset();
-			int decodedArrayPosition = decodedArrayOffset + decoded.position();
-			final int decodedArrayLimit = decodedArrayOffset + decoded.limit()
-					- decodedFragmentSize;
+            final int encodedArraySize = effectiveDecodedSize / 3 * 4;
+            final byte[] encodedArray = new byte[encodedArraySize];
+            int encodedArrayPosition = 0;
 
-			while (decodedArrayPosition < decodedArrayLimit) {
-				int byte0 = decodedArray[decodedArrayPosition++] & 0xff;
-				int byte1 = decodedArray[decodedArrayPosition++] & 0xff;
-				int byte2 = decodedArray[decodedArrayPosition++] & 0xff;
+            final byte[] decodedArray = decoded.array();
+            final int decodedArrayOffset = decoded.arrayOffset();
+            int decodedArrayPosition = decodedArrayOffset + decoded.position();
+            final int decodedArrayLimit = decodedArrayOffset + decoded.limit()
+                    - decodedFragmentSize;
 
-				encodedArray[encodedArrayPosition++] = INDEXED[(byte0 >> 2) & 0x3f];
-				encodedArray[encodedArrayPosition++] = INDEXED[((byte0 << 4) & 0x30)
-						| ((byte1 >> 4) & 0x0f)];
-				encodedArray[encodedArrayPosition++] = INDEXED[((byte1 << 2) & 0x3c)
-						| ((byte2 >> 6) & 0x03)];
-				encodedArray[encodedArrayPosition++] = INDEXED[byte2 & 0x3f];
-			}
+            while (decodedArrayPosition < decodedArrayLimit) {
+                int byte0 = decodedArray[decodedArrayPosition++] & 0xff;
+                int byte1 = decodedArray[decodedArrayPosition++] & 0xff;
+                int byte2 = decodedArray[decodedArrayPosition++] & 0xff;
 
-			switch (decodedFragmentSize) {
-			case 0:
-				break;
-			case 1: {
-				int byte0 = decodedArray[decodedArrayPosition++] & 0xff;
+                encodedArray[encodedArrayPosition++] = INDEXED[(byte0 >> 2) & 0x3f];
+                encodedArray[encodedArrayPosition++] = INDEXED[((byte0 << 4) & 0x30)
+                        | ((byte1 >> 4) & 0x0f)];
+                encodedArray[encodedArrayPosition++] = INDEXED[((byte1 << 2) & 0x3c)
+                        | ((byte2 >> 6) & 0x03)];
+                encodedArray[encodedArrayPosition++] = INDEXED[byte2 & 0x3f];
+            }
 
-				encodedArray[encodedArrayPosition++] = INDEXED[(byte0 >> 2) & 0x3f];
-				encodedArray[encodedArrayPosition++] = INDEXED[((byte0 << 4) & 0x30)];
-				encodedArray[encodedArrayPosition++] = PADDING_BYTE;
-				encodedArray[encodedArrayPosition++] = PADDING_BYTE;
-				break;
-			}
-			case 2: {
-				int byte0 = decodedArray[decodedArrayPosition++] & 0xff;
-				int byte1 = decodedArray[decodedArrayPosition++] & 0xff;
+            switch (decodedFragmentSize) {
+            case 0:
+                break;
+            case 1: {
+                int byte0 = decodedArray[decodedArrayPosition++] & 0xff;
 
-				encodedArray[encodedArrayPosition++] = INDEXED[(byte0 >> 2) & 0x3f];
-				encodedArray[encodedArrayPosition++] = INDEXED[((byte0 << 4) & 0x30)
-						| ((byte1 >> 4) & 0x0f)];
-				encodedArray[encodedArrayPosition++] = INDEXED[(byte1 << 2) & 0x3c];
-				encodedArray[encodedArrayPosition++] = PADDING_BYTE;
-				break;
-			}
-			default: {
-				throw new IllegalArgumentException("Invalid base64 encoding");
-			}
-			}
+                encodedArray[encodedArrayPosition++] = INDEXED[(byte0 >> 2) & 0x3f];
+                encodedArray[encodedArrayPosition++] = INDEXED[(byte0 << 4) & 0x30];
+                encodedArray[encodedArrayPosition++] = PADDING_BYTE;
+                encodedArray[encodedArrayPosition++] = PADDING_BYTE;
+                break;
+            }
+            case 2: {
+                int byte0 = decodedArray[decodedArrayPosition++] & 0xff;
+                int byte1 = decodedArray[decodedArrayPosition++] & 0xff;
 
-			return ByteBuffer.wrap(encodedArray);
-		}
+                encodedArray[encodedArrayPosition++] = INDEXED[(byte0 >> 2) & 0x3f];
+                encodedArray[encodedArrayPosition++] = INDEXED[((byte0 << 4) & 0x30)
+                        | ((byte1 >> 4) & 0x0f)];
+                encodedArray[encodedArrayPosition++] = INDEXED[(byte1 << 2) & 0x3c];
+                encodedArray[encodedArrayPosition++] = PADDING_BYTE;
+                break;
+            }
+            default: {
+                throw new IllegalArgumentException("Invalid base64 encoding");
+            }
+            }
 
-		public ByteBuffer decode(ByteBuffer encoded, DecodingState state) {
-			if (encoded.hasArray()) {
-				return decodeWithHeap(encoded, state);
-			}
-			else {
-				return decodeWithDirect(encoded, state);
-			}
-		}
-		
-		private ByteBuffer decodeWithDirect(ByteBuffer encoded, DecodingState state) {
-			final int length = encoded.remaining();
+            return ByteBuffer.wrap(encodedArray);
+        }
 
-			if (length % 4 != 0) {
-				throw new IllegalArgumentException("base64");
-			}
+        public ByteBuffer decode(ByteBuffer encoded, DecodingState state) {
+            if (encoded.hasArray()) {
+                return decodeWithHeap(encoded, state);
+            }
+            else {
+                return decodeWithDirect(encoded, state);
+            }
+        }
 
-			final byte[] decodedArray = new byte[(length / 4 * 3)];
-			int decodedArrayOffset = 0;
+        private ByteBuffer decodeWithDirect(ByteBuffer encoded, DecodingState state) {
+            final int length = encoded.remaining();
 
-			final int encodedArrayLimit = encoded.limit();
-			for (int i = encoded.position(); i < encodedArrayLimit;) {
-				// This would be faster reading an int (4 bytes) at a time
-				int char0 = encoded.get(i++);
-				int char1 = encoded.get(i++);
-				int char2 = encoded.get(i++);
-				int char3 = encoded.get(i++);
+            if (length % 4 != 0) {
+                throw new IllegalArgumentException("base64");
+            }
 
-				int byte0 = mapped(char0);
-				int byte1 = mapped(char1);
-				int byte2 = mapped(char2);
-				int byte3 = mapped(char3);
+            final byte[] decodedArray = new byte[length / 4 * 3];
+            int decodedArrayOffset = 0;
 
-				decodedArray[decodedArrayOffset++] = (byte) (((byte0 << 2) & 0xfc) | ((byte1 >> 4) & 0x03));
-				if (char2 != PADDING_BYTE) {
-					decodedArray[decodedArrayOffset++] = (byte) (((byte1 << 4) & 0xf0) | ((byte2 >> 2) & 0x0f));
-					if (char3 != PADDING_BYTE) {
-						decodedArray[decodedArrayOffset++] = (byte) (((byte2 << 6) & 0xc0) | (byte3 & 0x3f));
-					}
-				}
-			}
+            final int encodedArrayLimit = encoded.limit();
+            for (int i = encoded.position(); i < encodedArrayLimit;) {
+                // This would be faster reading an int (4 bytes) at a time
+                int char0 = encoded.get(i++);
+                int char1 = encoded.get(i++);
+                int char2 = encoded.get(i++);
+                int char3 = encoded.get(i++);
+
+                int byte0 = mapped(char0);
+                int byte1 = mapped(char1);
+                int byte2 = mapped(char2);
+                int byte3 = mapped(char3);
+
+                decodedArray[decodedArrayOffset++] = (byte) (((byte0 << 2) & 0xfc) | ((byte1 >> 4) & 0x03));
+                if (char2 != PADDING_BYTE) {
+                    decodedArray[decodedArrayOffset++] = (byte) (((byte1 << 4) & 0xf0) | ((byte2 >> 2) & 0x0f));
+                    if (char3 != PADDING_BYTE) {
+                        decodedArray[decodedArrayOffset++] = (byte) (((byte2 << 6) & 0xc0) | (byte3 & 0x3f));
+                    }
+                }
+            }
             return ByteBuffer.wrap(decodedArray, 0, decodedArrayOffset);
-		}
-		
-		private ByteBuffer decodeWithHeap(ByteBuffer encoded, DecodingState state) {
-			int length = encoded.remaining();
+        }
 
-			if (length % 4 != 0) {
-				throw new IllegalArgumentException("base64");
-			}
+        private ByteBuffer decodeWithHeap(ByteBuffer encoded, DecodingState state) {
+            int length = encoded.remaining();
 
-			byte[] decodedArray = new byte[(length / 4 * 3)];
-			int decodedArrayOffset = 0;
+            if (length % 4 != 0) {
+                throw new IllegalArgumentException("base64");
+            }
 
-			byte[] encodedArray = encoded.array();
-			int encodedArrayOffset = encoded.arrayOffset();
-			int encodedArrayLimit = encodedArrayOffset + encoded.limit();
-			for (int i = encodedArrayOffset + encoded.position(); i < encodedArrayLimit;) {
-				int char0 = encodedArray[i++];
-				int char1 = encodedArray[i++];
-				int char2 = encodedArray[i++];
-				int char3 = encodedArray[i++];
+            byte[] decodedArray = new byte[length / 4 * 3];
+            int decodedArrayOffset = 0;
 
-				int byte0 = mapped(char0);
-				int byte1 = mapped(char1);
-				int byte2 = mapped(char2);
-				int byte3 = mapped(char3);
+            byte[] encodedArray = encoded.array();
+            int encodedArrayOffset = encoded.arrayOffset();
+            int encodedArrayLimit = encodedArrayOffset + encoded.limit();
+            for (int i = encodedArrayOffset + encoded.position(); i < encodedArrayLimit;) {
+                int char0 = encodedArray[i++];
+                int char1 = encodedArray[i++];
+                int char2 = encodedArray[i++];
+                int char3 = encodedArray[i++];
 
-				decodedArray[decodedArrayOffset++] = (byte) (((byte0 << 2) & 0xfc) | ((byte1 >> 4) & 0x03));
-				if (char2 != PADDING_BYTE) {
-					decodedArray[decodedArrayOffset++] = (byte) (((byte1 << 4) & 0xf0) | ((byte2 >> 2) & 0x0f));
-					if (char3 != PADDING_BYTE) {
-						decodedArray[decodedArrayOffset++] = (byte) (((byte2 << 6) & 0xc0) | (byte3 & 0x3f));
-					}
-				}
-			}
-			return ByteBuffer.wrap(decodedArray, 0, decodedArrayOffset);
-		}
-	},
+                int byte0 = mapped(char0);
+                int byte1 = mapped(char1);
+                int byte2 = mapped(char2);
+                int byte3 = mapped(char3);
+
+                decodedArray[decodedArrayOffset++] = (byte) (((byte0 << 2) & 0xfc) | ((byte1 >> 4) & 0x03));
+                if (char2 != PADDING_BYTE) {
+                    decodedArray[decodedArrayOffset++] = (byte) (((byte1 << 4) & 0xf0) | ((byte2 >> 2) & 0x0f));
+                    if (char3 != PADDING_BYTE) {
+                        decodedArray[decodedArrayOffset++] = (byte) (((byte2 << 6) & 0xc0) | (byte3 & 0x3f));
+                    }
+                }
+            }
+            return ByteBuffer.wrap(decodedArray, 0, decodedArrayOffset);
+        }
+    },
     UTF8 {
         public ByteBuffer encode(ByteBuffer decoded) {
             return encodeBinaryAsText(decoded, true, false);
@@ -274,84 +274,86 @@ public enum Encoding {
         }
     };
 
-	public abstract ByteBuffer encode(ByteBuffer buf);
+    public abstract ByteBuffer encode(ByteBuffer buf);
 
-	public abstract ByteBuffer decode(ByteBuffer buf, DecodingState state);
-	
-	/**
-	 * WARNING: this method will throw a runtime exception if there is incomplete data at the end of buf 
-	 * (e.g. first byte of a two byte UTF8 character or escaped byte). For that use decode(IoBuffer, DecodingState).
+    public abstract ByteBuffer decode(ByteBuffer buf, DecodingState state);
+
+    /**
+     * WARNING: this method will throw a runtime exception if there is incomplete data at the end of buf
+     * (e.g. first byte of a two byte UTF8 character or escaped byte). For that use decode(IoBuffer, DecodingState).
      * @throws UnsupportedOperationException - if the last byte is part of an incomplete sequence
-	 */
-	public ByteBuffer decode(ByteBuffer buf) {
-	    return decode(buf, DecodingState.NONE);
-	}
+     */
+    public ByteBuffer decode(ByteBuffer buf) {
+        return decode(buf, DecodingState.NONE);
+    }
 
-	private static final byte[] INDEXED = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-			.getBytes();
-	private static final int PADDING_BYTE = (int) '=';
+    private static final byte[] INDEXED = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+            .getBytes();
+    private static final int PADDING_BYTE = (int) '=';
 
-	private static final int mapped(int ch) {
-		if ((ch & 0x40) != 0) {
-			if ((ch & 0x20) != 0) {
-				// a(01100001)-z(01111010) -> 26-51
-				assert (ch >= 'a');
-				assert (ch <= 'z');
-				return (ch - 71);
-			} else {
-				// A(01000001)-Z(01011010) -> 0-25
-				assert (ch >= 'A');
-				assert (ch <= 'Z');
-				return (ch - 65);
-			}
-		} else if ((ch & 0x20) != 0) {
-			if ((ch & 0x10) != 0) {
-				if ((ch & 0x08) != 0 && (ch & 0x04) != 0) {
-					// =(00111101) -> 0
-					assert (ch == '=');
-					return 0;
-				}
-				else {
-					// 0(00110000)-9(00111001) -> 52-61
-					assert (ch >= '0');
-					assert (ch <= '9');
-					return (ch + 4);
-				}
-			} else {
-				if ((ch & 0x04) != 0) {
-					// /(00101111) -> 63
-					assert (ch == '/');
-					return 63;
-				} else {
-					// +(00101011) -> 62
-					assert (ch == '+');
-					return 62;
-				}
-			}
-		} else {
-			throw new IllegalArgumentException("Invalid BASE64 string");
-		}
-	}
+    private static int mapped(int ch) {
+        if ((ch & 0x40) != 0) {
+            if ((ch & 0x20) != 0) {
+                // a(01100001)-z(01111010) -> 26-51
+                assert ch >= 'a';
+                assert ch <= 'z';
+                return ch - 71;
+            } else {
+                // A(01000001)-Z(01011010) -> 0-25
+                assert ch >= 'A';
+                assert ch <= 'Z';
+                return ch - 65;
+            }
+        } else if ((ch & 0x20) != 0) {
+            if ((ch & 0x10) != 0) {
+                if ((ch & 0x08) != 0 && (ch & 0x04) != 0) {
+                    // =(00111101) -> 0
+                    assert ch == '=';
+                    return 0;
+                }
+                else {
+                    // 0(00110000)-9(00111001) -> 52-61
+                    assert ch >= '0';
+                    assert ch <= '9';
+                    return ch + 4;
+                }
+            } else {
+                if ((ch & 0x04) != 0) {
+                    // /(00101111) -> 63
+                    assert ch == '/';
+                    return 63;
+                } else {
+                    // +(00101011) -> 62
+                    assert ch == '+';
+                    return 62;
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("Invalid BASE64 string");
+        }
+    }
 
-	private static final ByteBuffer encodeBinaryAsText(ByteBuffer decoded, boolean encodeAsUTF8, boolean escapeZeroAndNewline) {
-		if (decoded.hasArray()) {
-			return encodeBinaryAsTextWithHeap(decoded, encodeAsUTF8, escapeZeroAndNewline);
-		}
-		else {
-			return encodeBinaryAsTextWithDirect(decoded, encodeAsUTF8, escapeZeroAndNewline);
-		}
-	}
+    private static ByteBuffer encodeBinaryAsText(ByteBuffer decoded, boolean encodeAsUTF8, boolean escapeZeroAndNewline) {
+        if (decoded.hasArray()) {
+            return encodeBinaryAsTextWithHeap(decoded, encodeAsUTF8, escapeZeroAndNewline);
+        }
+        else {
+            return encodeBinaryAsTextWithDirect(decoded, encodeAsUTF8, escapeZeroAndNewline);
+        }
+    }
 
-	private static final ByteBuffer encodeBinaryAsTextWithDirect(ByteBuffer decoded, boolean encodeAsUTF8, boolean escapeZeroAndNewline) {
+    private static ByteBuffer encodeBinaryAsTextWithDirect(ByteBuffer decoded,
+                                                           boolean encodeAsUTF8,
+                                                           boolean escapeZeroAndNewline) {
         int decodedPosition = decoded.position();
         final int decodedInitialPosition = decodedPosition;
         final int decodedLimit = decoded.limit();
-        
+
         byte[] encodedArray = null;
         int encodedArrayInsertionCount = 0;
-        for (;decodedPosition < decodedLimit; decodedPosition++) {
+        for (; decodedPosition < decodedLimit; decodedPosition++) {
             byte decodedValue = decoded.get(decodedPosition);
-            
+
             if (escapeZeroAndNewline) {
                 switch (decodedValue) {
                 case 0x00:
@@ -359,7 +361,8 @@ public enum Encoding {
                     encodedArray = supplyEncodedArray(decoded, decodedPosition, decodedLimit, encodedArray);
 
                     // 0x00 -> 0x7f 0x30 ('0')
-                    encodedArrayInsertionCount = updateEncodedArray(decodedPosition, encodedArray, encodedArrayInsertionCount, (byte)0x7f, (byte)0x30);
+                    encodedArrayInsertionCount = updateEncodedArray(decodedPosition, encodedArray,
+                            encodedArrayInsertionCount, (byte) 0x7f, (byte) 0x30);
 
                     // advance to next byte
                     continue;
@@ -368,7 +371,8 @@ public enum Encoding {
                     encodedArray = supplyEncodedArray(decoded, decodedPosition, decodedLimit, encodedArray);
 
                     // 0x0a -> 0x7f 0x6e ('n')
-                    encodedArrayInsertionCount = updateEncodedArray(decodedPosition, encodedArray, encodedArrayInsertionCount, (byte)0x7f, (byte)0x6e);
+                    encodedArrayInsertionCount = updateEncodedArray(decodedPosition, encodedArray, encodedArrayInsertionCount,
+                            (byte) 0x7f, (byte) 0x6e);
 
                     // advance to next byte
                     continue;
@@ -377,7 +381,8 @@ public enum Encoding {
                     encodedArray = supplyEncodedArray(decoded, decodedPosition, decodedLimit, encodedArray);
 
                     // 0x0d -> 0x7f 0x72 ('r')
-                    encodedArrayInsertionCount = updateEncodedArray(decodedPosition, encodedArray, encodedArrayInsertionCount, (byte)0x7f, (byte)0x72);
+                    encodedArrayInsertionCount = updateEncodedArray(decodedPosition, encodedArray, encodedArrayInsertionCount,
+                            (byte) 0x7f, (byte) 0x72);
 
                     // advance to next byte
                     continue;
@@ -386,99 +391,116 @@ public enum Encoding {
                     encodedArray = supplyEncodedArray(decoded, decodedPosition, decodedLimit, encodedArray);
 
                     // 0x7f -> 0x7f 0x7f
-                    encodedArrayInsertionCount = updateEncodedArray(decodedPosition, encodedArray, encodedArrayInsertionCount, (byte)0x7f, (byte)0x7f);
-                    
+                    encodedArrayInsertionCount = updateEncodedArray(decodedPosition, encodedArray, encodedArrayInsertionCount,
+                            (byte) 0x7f, (byte) 0x7f);
+
                     // advance to next byte
                     continue;
                 }
             }
-            
+
             if (encodeAsUTF8 && (decodedValue & 0x80) != 0) {
                 // high bit set, requires multi-byte representation in UTF8
                 encodedArray = supplyEncodedArray(decoded, decodedPosition, decodedLimit, encodedArray);
-                
-                byte encodedByte0 = (byte)((((decodedValue & 0xff) >> 6) & 0x03) | 0xc0);
-                byte encodedByte1 = (byte)(decodedValue & 0xbf);
-                encodedArrayInsertionCount = updateEncodedArray(decodedPosition, encodedArray, encodedArrayInsertionCount, encodedByte0, encodedByte1);
+
+                byte encodedByte0 = (byte) ((((decodedValue & 0xff) >> 6) & 0x03) | 0xc0);
+                byte encodedByte1 = (byte) (decodedValue & 0xbf);
+                encodedArrayInsertionCount = updateEncodedArray(decodedPosition, encodedArray, encodedArrayInsertionCount,
+                        encodedByte0, encodedByte1);
             }
             else if (encodedArray != null) {
                 updateEncodedArray(decodedPosition, encodedArray, encodedArrayInsertionCount, decodedValue);
             }
         }
-        
-        return (encodedArray != null) ? ByteBuffer.wrap(encodedArray, decodedInitialPosition, decoded.remaining() + encodedArrayInsertionCount) : decoded;
-	}
-	
-	private static final ByteBuffer encodeBinaryAsTextWithHeap(ByteBuffer decoded, boolean encodeAsUTF8, boolean escapeZeroAndNewline) {
+
+        return (encodedArray != null) ? ByteBuffer.wrap(encodedArray, decodedInitialPosition,
+                                                        decoded.remaining() + encodedArrayInsertionCount) : decoded;
+    }
+
+    private static ByteBuffer encodeBinaryAsTextWithHeap(ByteBuffer decoded,
+                                                         boolean encodeAsUTF8,
+                                                         boolean escapeZeroAndNewline) {
         byte[] decodedArray = decoded.array();
         final int decodedArrayOffset = decoded.arrayOffset();
         int decodedArrayPosition = decodedArrayOffset + decoded.position();
         final int decodedArrayInitialPosition = decodedArrayPosition;
         final int decodedArrayLimit = decodedArrayOffset + decoded.limit();
-        
+
         byte[] encodedArray = null;
         int encodedArrayInsertionCount = 0;
-        for (;decodedArrayPosition < decodedArrayLimit; decodedArrayPosition++) {
+        for (; decodedArrayPosition < decodedArrayLimit; decodedArrayPosition++) {
             byte decodedValue = decodedArray[decodedArrayPosition];
-            
+
             if (escapeZeroAndNewline) {
                 switch (decodedValue) {
                 case 0x00:
                     // null byte, requires multi-byte escaped representation
-                    encodedArray = supplyEncodedArray(decodedArray, decodedArrayOffset, decodedArrayPosition, decodedArrayLimit, encodedArray);
+                    encodedArray = supplyEncodedArray(decodedArray, decodedArrayOffset, decodedArrayPosition,
+                            decodedArrayLimit, encodedArray);
 
                     // 0x00 -> 0x7f 0x30 ('0')
-                    encodedArrayInsertionCount = updateEncodedArray(decodedArrayPosition, encodedArray, encodedArrayInsertionCount, (byte)0x7f, (byte)0x30);
+                    encodedArrayInsertionCount = updateEncodedArray(decodedArrayPosition, encodedArray,
+                            encodedArrayInsertionCount, (byte) 0x7f, (byte) 0x30);
 
                     // advance to next byte
                     continue;
                 case 0x0a:
                     // newline byte, requires multi-byte escaped representation
-                    encodedArray = supplyEncodedArray(decodedArray, decodedArrayOffset, decodedArrayPosition, decodedArrayLimit, encodedArray);
+                    encodedArray = supplyEncodedArray(decodedArray, decodedArrayOffset, decodedArrayPosition,
+                            decodedArrayLimit, encodedArray);
 
                     // 0x0a -> 0x7f 0x6e ('n')
-                    encodedArrayInsertionCount = updateEncodedArray(decodedArrayPosition, encodedArray, encodedArrayInsertionCount, (byte)0x7f, (byte)0x6e);
+                    encodedArrayInsertionCount = updateEncodedArray(decodedArrayPosition, encodedArray,
+                            encodedArrayInsertionCount, (byte) 0x7f, (byte) 0x6e);
 
                     // advance to next byte
                     continue;
                 case 0x0d:
                     // carriage return byte, requires multi-byte escaped representation
-                    encodedArray = supplyEncodedArray(decodedArray, decodedArrayOffset, decodedArrayPosition, decodedArrayLimit, encodedArray);
+                    encodedArray = supplyEncodedArray(decodedArray, decodedArrayOffset, decodedArrayPosition,
+                            decodedArrayLimit, encodedArray);
 
                     // 0x0d -> 0x7f 0x72 ('r')
-                    encodedArrayInsertionCount = updateEncodedArray(decodedArrayPosition, encodedArray, encodedArrayInsertionCount, (byte)0x7f, (byte)0x72);
+                    encodedArrayInsertionCount = updateEncodedArray(decodedArrayPosition, encodedArray,
+                            encodedArrayInsertionCount, (byte) 0x7f, (byte) 0x72);
 
                     // advance to next byte
                     continue;
                 case 0x7f:
                     // escape prefix byte, requires multi-byte escaped representation
-                    encodedArray = supplyEncodedArray(decodedArray, decodedArrayOffset, decodedArrayPosition, decodedArrayLimit, encodedArray);
+                    encodedArray = supplyEncodedArray(decodedArray, decodedArrayOffset, decodedArrayPosition,
+                            decodedArrayLimit, encodedArray);
 
                     // 0x7f -> 0x7f 0x7f
-                    encodedArrayInsertionCount = updateEncodedArray(decodedArrayPosition, encodedArray, encodedArrayInsertionCount, (byte)0x7f, (byte)0x7f);
-                    
+                    encodedArrayInsertionCount = updateEncodedArray(decodedArrayPosition, encodedArray,
+                            encodedArrayInsertionCount, (byte) 0x7f, (byte) 0x7f);
+
                     // advance to next byte
                     continue;
                 }
             }
-            
+
             if (encodeAsUTF8 && (decodedValue & 0x80) != 0) {
                 // high bit set, requires multi-byte representation in UTF8
-                encodedArray = supplyEncodedArray(decodedArray, decodedArrayOffset, decodedArrayPosition, decodedArrayLimit, encodedArray);
-                
-                byte encodedByte0 = (byte)((((decodedValue & 0xff) >> 6) & 0x03) | 0xc0);
-                byte encodedByte1 = (byte)(decodedValue & 0xbf);
-                encodedArrayInsertionCount = updateEncodedArray(decodedArrayPosition, encodedArray, encodedArrayInsertionCount, encodedByte0, encodedByte1);
+                encodedArray = supplyEncodedArray(decodedArray, decodedArrayOffset, decodedArrayPosition,
+                        decodedArrayLimit, encodedArray);
+
+                byte encodedByte0 = (byte) ((((decodedValue & 0xff) >> 6) & 0x03) | 0xc0);
+                byte encodedByte1 = (byte) (decodedValue & 0xbf);
+                encodedArrayInsertionCount = updateEncodedArray(decodedArrayPosition, encodedArray,
+                        encodedArrayInsertionCount, encodedByte0, encodedByte1);
             }
             else if (encodedArray != null) {
                 updateEncodedArray(decodedArrayPosition, encodedArray, encodedArrayInsertionCount, decodedValue);
             }
         }
-        
-        return (encodedArray != null) ? ByteBuffer.wrap(encodedArray, decodedArrayInitialPosition, decoded.remaining() + encodedArrayInsertionCount) : decoded;
+
+        return (encodedArray != null) ? ByteBuffer.wrap(encodedArray, decodedArrayInitialPosition,
+                                                        decoded.remaining() + encodedArrayInsertionCount) : decoded;
     }
 
-    private static byte[] supplyEncodedArray(byte[] decodedArray, int decodedArrayOffset, int decodedArrayPosition, int decodedArrayLimit, byte[] encodedArray) {
+    private static byte[] supplyEncodedArray(byte[] decodedArray, int decodedArrayOffset, int decodedArrayPosition,
+                                             int decodedArrayLimit, byte[] encodedArray) {
         if (encodedArray == null) {
             int decodedPosition = decodedArrayPosition - decodedArrayOffset;
             int decodedRemaining = decodedArrayLimit - decodedArrayPosition;
@@ -487,12 +509,12 @@ public enum Encoding {
         }
         return encodedArray;
     }
-    
+
     private static byte[] supplyEncodedArray(ByteBuffer decoded, int decodedPosition, int decodedLimit, byte[] encodedArray) {
         if (encodedArray == null) {
             int decodedRemaining = decodedLimit - decodedPosition;
             encodedArray = new byte[decodedPosition + decodedRemaining * 2];
-            
+
             int originalPosition = decoded.position();
             decoded.position(0);
             decoded.get(encodedArray, 0, decodedPosition);
@@ -500,28 +522,32 @@ public enum Encoding {
         }
         return encodedArray;
     }
-    
-    private static int updateEncodedArray(int decodedArrayPosition, byte[] encodedArray, int encodedArrayInsertionCount, byte byte0, byte byte1) {
+
+    private static int updateEncodedArray(int decodedArrayPosition, byte[] encodedArray, int encodedArrayInsertionCount,
+                                          byte byte0, byte byte1) {
         updateEncodedArray(decodedArrayPosition, encodedArray, encodedArrayInsertionCount, byte0);
         encodedArrayInsertionCount++;
         updateEncodedArray(decodedArrayPosition, encodedArray, encodedArrayInsertionCount, byte1);
         return encodedArrayInsertionCount;
     }
 
-    private static void updateEncodedArray(int decodedArrayPosition, byte[] encodedArray, int encodedArrayInsertionCount, byte encodedByte) {
+    private static void updateEncodedArray(int decodedArrayPosition, byte[] encodedArray, int encodedArrayInsertionCount,
+                                           byte encodedByte) {
         encodedArray[decodedArrayPosition + encodedArrayInsertionCount] = encodedByte;
     }
 
-    private static final ByteBuffer decodeTextAsBinary(ByteBuffer encoded, DecodingState state, boolean decodeAsUTF8, boolean unescapeZeroAndNewline) {
-    	if (encoded.hasArray()) {
-    		return decodeTextAsBinaryWithHeap(encoded, state, decodeAsUTF8, unescapeZeroAndNewline);
-    	}
-    	else {
-    		return decodeTextAsBinaryWithDirect(encoded, state, decodeAsUTF8, unescapeZeroAndNewline);
-    	}
+    private static ByteBuffer decodeTextAsBinary(ByteBuffer encoded, DecodingState state, boolean decodeAsUTF8,
+                                                       boolean unescapeZeroAndNewline) {
+        if (encoded.hasArray()) {
+            return decodeTextAsBinaryWithHeap(encoded, state, decodeAsUTF8, unescapeZeroAndNewline);
+        }
+        else {
+            return decodeTextAsBinaryWithDirect(encoded, state, decodeAsUTF8, unescapeZeroAndNewline);
+        }
     }
-    
-    private static final ByteBuffer decodeTextAsBinaryWithHeap(ByteBuffer encoded, DecodingState state, boolean decodeAsUTF8, boolean unescapeZeroAndNewline) {
+
+    private static ByteBuffer decodeTextAsBinaryWithHeap(ByteBuffer encoded, DecodingState state,
+                                                               boolean decodeAsUTF8, boolean unescapeZeroAndNewline) {
         byte[] encodedArray = encoded.array();
         // Maintain offset, position and limit for the portion that interests us (from position() to limit())
         int encodedArrayOffset = encoded.arrayOffset() + encoded.position();
@@ -530,7 +556,7 @@ public enum Encoding {
 
         byte[] decodedArray = null;
         int encodedArrayInsertionCount = 0;
-        Byte previousRemainingByte = (Byte)state.get(); // first byte of a byte pair left over from end of last packet, or null
+        Byte previousRemainingByte = (Byte) state.get(); // first byte of a byte pair left over from end of last packet, or null
         if (previousRemainingByte != null) {
             decodedArray = new byte[encoded.remaining()];
             // pretend the extra byte from the last packet is just before the first byte of this packet
@@ -538,25 +564,28 @@ public enum Encoding {
             encodedArrayOffset--;
         }
         Byte remainingByte = null;
-        
-        for (;encodedArrayPosition < encodedArrayLimit; encodedArrayPosition++) {
+
+        for (; encodedArrayPosition < encodedArrayLimit; encodedArrayPosition++) {
             byte encodedByte1 = encodedArrayPosition == -1 ? previousRemainingByte : encodedArray[encodedArrayPosition];
             if (decodeAsUTF8 && (encodedByte1 & 0x80) != 0) {
                 // high bit set, consumes multi-byte representation in UTF8
-                decodedArray = supplyDecodedArray(encodedArray, encodedArrayOffset, encodedArrayPosition, encodedArrayLimit, decodedArray);
+                decodedArray = supplyDecodedArray(encodedArray, encodedArrayOffset, encodedArrayPosition,
+                        encodedArrayLimit, decodedArray);
                 if (++encodedArrayPosition >= encodedArrayLimit) {
                     remainingByte = encodedByte1;
                     encodedArrayInsertionCount++;
                     break;
                 }
                 byte encodedByte2 = encodedArray[encodedArrayPosition];
-                byte decodedByte = (byte)((encodedByte1 << 6) | (encodedByte2 & 0x3f));
-                encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition, decodedArray, encodedArrayInsertionCount, decodedByte);
+                byte decodedByte = (byte) ((encodedByte1 << 6) | (encodedByte2 & 0x3f));
+                encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition,
+                        decodedArray, encodedArrayInsertionCount, decodedByte);
             }
             else {
                 if (unescapeZeroAndNewline && encodedByte1 == 0x7f) {
-                    decodedArray = supplyDecodedArray(encodedArray, encodedArrayOffset, encodedArrayPosition, encodedArrayLimit, decodedArray);
-                    
+                    decodedArray = supplyDecodedArray(encodedArray, encodedArrayOffset, encodedArrayPosition,
+                            encodedArrayLimit, decodedArray);
+
                     if (++encodedArrayPosition >= encodedArrayLimit) {
                         remainingByte = encodedByte1;
                         encodedArrayInsertionCount++;
@@ -566,19 +595,23 @@ public enum Encoding {
                     switch (encodedByte2) {
                     case 0x30:
                         // '0'
-                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition, decodedArray, encodedArrayInsertionCount, (byte)0x00);
+                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition,
+                                decodedArray, encodedArrayInsertionCount, (byte) 0x00);
                         break;
                     case 0x6e:
                         // 'n'
-                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition, decodedArray, encodedArrayInsertionCount, (byte)0x0a);
+                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition,
+                                decodedArray, encodedArrayInsertionCount, (byte) 0x0a);
                         break;
                     case 0x72:
                         // 'r'
-                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition, decodedArray, encodedArrayInsertionCount, (byte)0x0d);
+                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition,
+                                decodedArray, encodedArrayInsertionCount, (byte) 0x0d);
                         break;
                     default:
                         // tolerate 0x7f [not 0 or n] -> [not 0 or n]
-                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition, decodedArray, encodedArrayInsertionCount, encodedByte2);
+                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition,
+                                decodedArray, encodedArrayInsertionCount, encodedByte2);
                         break;
                     }
                 }
@@ -591,8 +624,9 @@ public enum Encoding {
         int decodedLength = encoded.remaining() + (previousRemainingByte != null ? 1 : 0) - encodedArrayInsertionCount;
         return (decodedArray != null) ? ByteBuffer.wrap(decodedArray, 0, decodedLength) : encoded;
     }
-    
-    private static final ByteBuffer decodeTextAsBinaryWithDirect(ByteBuffer encoded, DecodingState state, boolean decodeAsUTF8, boolean unescapeZeroAndNewline) {
+
+    private static ByteBuffer decodeTextAsBinaryWithDirect(ByteBuffer encoded, DecodingState state,
+                                                                 boolean decodeAsUTF8, boolean unescapeZeroAndNewline) {
         // Maintain offset, position and limit for the portion that interests us (from position() to limit())
         int encodedArrayOffset = encoded.position();
         int encodedArrayPosition = encodedArrayOffset;
@@ -600,7 +634,7 @@ public enum Encoding {
 
         byte[] decodedArray = null;
         int encodedArrayInsertionCount = 0;
-        Byte previousRemainingByte = (Byte)state.get(); // first byte of a byte pair left over from end of last packet, or null
+        Byte previousRemainingByte = (Byte) state.get(); // first byte of a byte pair left over from end of last packet, or null
         if (previousRemainingByte != null) {
             decodedArray = new byte[encoded.remaining()];
             // pretend the extra byte from the last packet is just before the first byte of this packet
@@ -608,25 +642,28 @@ public enum Encoding {
             encodedArrayOffset--;
         }
         Byte remainingByte = null;
-        
-        for (;encodedArrayPosition < encodedArrayLimit; encodedArrayPosition++) {
+
+        for (; encodedArrayPosition < encodedArrayLimit; encodedArrayPosition++) {
             byte encodedByte1 = encodedArrayPosition == -1 ? previousRemainingByte : encoded.get(encodedArrayPosition);
             if (decodeAsUTF8 && (encodedByte1 & 0x80) != 0) {
                 // high bit set, consumes multi-byte representation in UTF8
-                decodedArray = supplyDecodedArray(encoded, encodedArrayOffset, encodedArrayPosition, encodedArrayLimit, decodedArray);
+                decodedArray = supplyDecodedArray(encoded, encodedArrayOffset, encodedArrayPosition,
+                        encodedArrayLimit, decodedArray);
                 if (++encodedArrayPosition >= encodedArrayLimit) {
                     remainingByte = encodedByte1;
                     encodedArrayInsertionCount++;
                     break;
                 }
                 byte encodedByte2 = encoded.get(encodedArrayPosition);
-                byte decodedByte = (byte)((encodedByte1 << 6) | (encodedByte2 & 0x3f));
-                encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition, decodedArray, encodedArrayInsertionCount, decodedByte);
+                byte decodedByte = (byte) ((encodedByte1 << 6) | (encodedByte2 & 0x3f));
+                encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition, decodedArray,
+                        encodedArrayInsertionCount, decodedByte);
             }
             else {
                 if (unescapeZeroAndNewline && encodedByte1 == 0x7f) {
-                    decodedArray = supplyDecodedArray(encoded, encodedArrayOffset, encodedArrayPosition, encodedArrayLimit, decodedArray);
-                    
+                    decodedArray = supplyDecodedArray(encoded, encodedArrayOffset, encodedArrayPosition,
+                            encodedArrayLimit, decodedArray);
+
                     if (++encodedArrayPosition >= encodedArrayLimit) {
                         remainingByte = encodedByte1;
                         encodedArrayInsertionCount++;
@@ -636,19 +673,23 @@ public enum Encoding {
                     switch (encodedByte2) {
                     case 0x30:
                         // '0'
-                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition, decodedArray, encodedArrayInsertionCount, (byte)0x00);
+                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition,
+                                decodedArray, encodedArrayInsertionCount, (byte) 0x00);
                         break;
                     case 0x6e:
                         // 'n'
-                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition, decodedArray, encodedArrayInsertionCount, (byte)0x0a);
+                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition,
+                                decodedArray, encodedArrayInsertionCount, (byte) 0x0a);
                         break;
                     case 0x72:
                         // 'r'
-                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition, decodedArray, encodedArrayInsertionCount, (byte)0x0d);
+                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition,
+                                decodedArray, encodedArrayInsertionCount, (byte) 0x0d);
                         break;
                     default:
                         // tolerate 0x7f [not 0 or n] -> [not 0 or n]
-                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition, decodedArray, encodedArrayInsertionCount, encodedByte2);
+                        encodedArrayInsertionCount = updateDecodedArray(encodedArrayOffset, encodedArrayPosition,
+                                decodedArray, encodedArrayInsertionCount, encodedByte2);
                         break;
                     }
                 }
@@ -662,13 +703,15 @@ public enum Encoding {
         return (decodedArray != null) ? ByteBuffer.wrap(decodedArray, 0, decodedLength) : encoded;
     }
 
-    private static int updateDecodedArray(int encodedArrayOffset, int encodedArrayPosition, byte[] decodedArray, int encodedArrayInsertionCount, byte decodedByte) {
+    private static int updateDecodedArray(int encodedArrayOffset, int encodedArrayPosition, byte[] decodedArray,
+                                          int encodedArrayInsertionCount, byte decodedByte) {
         encodedArrayInsertionCount++;
         decodedArray[encodedArrayPosition - encodedArrayInsertionCount - encodedArrayOffset] = decodedByte;
         return encodedArrayInsertionCount;
     }
 
-    private static byte[] supplyDecodedArray(byte[] encodedArray, int encodedArrayOffset, int encodedArrayPosition, int encodedArrayLimit, byte[] decodedArray) {
+    private static byte[] supplyDecodedArray(byte[] encodedArray, int encodedArrayOffset, int encodedArrayPosition,
+                                             int encodedArrayLimit, byte[] decodedArray) {
         if (decodedArray == null) {
             int encodedPosition = encodedArrayPosition - encodedArrayOffset;
             int encodedRemaining = encodedArrayLimit - encodedArrayPosition;
@@ -677,14 +720,16 @@ public enum Encoding {
         }
         return decodedArray;
     }
-    
-    private static byte[] supplyDecodedArray(ByteBuffer encoded, int encodedArrayOffset, int encodedArrayPosition, int encodedArrayLimit, byte[] decodedArray) {
+
+    private static byte[] supplyDecodedArray(ByteBuffer encoded, int encodedArrayOffset, int encodedArrayPosition,
+                                             int encodedArrayLimit, byte[] decodedArray) {
         if (decodedArray == null) {
             int encodedPosition = encodedArrayPosition - encodedArrayOffset;
             int encodedRemaining = encodedArrayLimit - encodedArrayPosition;
             decodedArray = new byte[encodedPosition + encodedRemaining];
             encoded.get(decodedArray, 0, encodedPosition);
-            encoded.position(encoded.position() - encodedPosition); // back it up - get() on previous line consumes bytes from encoded
+            // back it up - get() on previous line consumes bytes from encoded
+            encoded.position(encoded.position() - encodedPosition);
         }
         return decodedArray;
     }

--- a/src/main/java/org/kaazing/gateway/util/GL.java
+++ b/src/main/java/org/kaazing/gateway/util/GL.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,13 +26,16 @@ import org.slf4j.LoggerFactory;
 
 public class GL {
 
+    protected GL() {
+    }
+
     public static final void info(String module, String format, Object ... args) {
         Logger logger = LoggerFactory.getLogger(module);
         if (logger.isInfoEnabled()) {
             logger.info(format, args);
         }
     }
-    
+
     public static final void debug(String module, String format, Object ... args) {
         Logger logger = LoggerFactory.getLogger(module);
         if (logger.isDebugEnabled()) {
@@ -60,7 +63,7 @@ public class GL {
             logger.warn(format, args);
         }
     }
-    
+
     public static final String identity(Object obj) {
         return obj.getClass().getSimpleName() + "@" + obj.hashCode();
     }

--- a/src/main/java/org/kaazing/gateway/util/InternalSystemProperty.java
+++ b/src/main/java/org/kaazing/gateway/util/InternalSystemProperty.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -32,38 +32,73 @@ public enum InternalSystemProperty {
     //       (e.g. in NioSocketAcceptor)
 
     // transports
-    DEBUG_NIOWORKER_POOL("NioWorkerPool.DEBUG"), // true or false
-    WS_ENABLED_TRANSPORTS("org.kaazing.gateway.server.transport.ws.ENABLED_TRANSPORTS"),
-    WSE_IDLE_TIMEOUT("org.kaazing.gateway.server.transport.wse.IDLE_TIMEOUT", "60"),
-    // We are deliberately changing the default that Netty uses (availableProcessors() * 2 ):
-    TCP_PROCESSOR_COUNT("org.kaazing.gateway.server.transport.tcp.PROCESSOR_COUNT", Integer.toString(getRuntime().availableProcessors())),
+    DEBUG_NIOWORKER_POOL
+            ("NioWorkerPool.DEBUG"), // true or false
+
+    WS_ENABLED_TRANSPORTS
+            ("org.kaazing.gateway.server.transport.ws.ENABLED_TRANSPORTS"),
+
+    WSE_IDLE_TIMEOUT
+            ("org.kaazing.gateway.server.transport.wse.IDLE_TIMEOUT", "60"),
+
+    // We are deliberately changing the default that Netty uses (availableProcessors() * 2):
+    TCP_PROCESSOR_COUNT
+            ("org.kaazing.gateway.server.transport.tcp.PROCESSOR_COUNT", Integer.toString(getRuntime().availableProcessors())),
 
     // Thread Pool Size for background tasks
-    BACKGROUND_TASK_THREADS("org.kaazing.gateway.server.util.scheduler.BACKGROUND_TASK_THREADS", Integer.toString(getRuntime().availableProcessors())),
+    BACKGROUND_TASK_THREADS
+            ("org.kaazing.gateway.server.util.scheduler.BACKGROUND_TASK_THREADS",
+                    Integer.toString(getRuntime().availableProcessors())),
 
     // These Buffer sizes were used by Mina. I'm pretty sure they no longer apply.
-    TCP_READ_BUFFER_SIZE("org.kaazing.gateway.server.transport.tcp.READ_BUFFER_SIZE"),
-    TCP_MINIMUM_READ_BUFFER_SIZE("org.kaazing.gateway.server.transport.tcp.MINIMUM_READ_BUFFER_SIZE"),
-    TCP_MAXIMUM_READ_BUFFER_SIZE("org.kaazing.gateway.server.transport.tcp.MAXIMUM_READ_BUFFER_SIZE"),
-    TCP_WRITE_TIMEOUT("org.kaazing.gateway.server.transport.tcp.WRITE_TIMEOUT"),
-    
+    TCP_READ_BUFFER_SIZE
+            ("org.kaazing.gateway.server.transport.tcp.READ_BUFFER_SIZE"),
+
+    TCP_MINIMUM_READ_BUFFER_SIZE
+            ("org.kaazing.gateway.server.transport.tcp.MINIMUM_READ_BUFFER_SIZE"),
+
+    TCP_MAXIMUM_READ_BUFFER_SIZE
+            ("org.kaazing.gateway.server.transport.tcp.MAXIMUM_READ_BUFFER_SIZE"),
+
+    TCP_WRITE_TIMEOUT
+            ("org.kaazing.gateway.server.transport.tcp.WRITE_TIMEOUT"),
+
     // Socket Channel Config options (SocketChannelIoSessionConfig)
-    TCP_REUSE_ADDRESS("org.kaazing.gateway.server.transport.tcp.REUSE_ADDRESS", "true"),
-    TCP_NO_DELAY("org.kaazing.gateway.server.transport.tcp.TCP_NO_DELAY"),
-    TCP_BACKLOG("org.kaazing.gateway.server.transport.tcp.BACKLOG"),
-    TCP_KEEP_ALIVE("org.kaazing.gateway.server.transport.tcp.KEEP_ALIVE"),
-    TCP_RECEIVE_BUFFER_SIZE("org.kaazing.gateway.server.transport.tcp.RECEIVE_BUFFER_SIZE"),
-    TCP_SEND_BUFFER_SIZE("org.kaazing.gateway.server.transport.tcp.SEND_BUFFER_SIZE"),
-    TCP_SO_LINGER("org.kaazing.gateway.server.transport.tcp.SO_LINGER"),
-    TCP_IP_TOS("org.kaazing.gateway.server.transport.tcp.IP_TOS"),
+    TCP_REUSE_ADDRESS
+            ("org.kaazing.gateway.server.transport.tcp.REUSE_ADDRESS", "true"),
+
+    TCP_NO_DELAY
+            ("org.kaazing.gateway.server.transport.tcp.TCP_NO_DELAY"),
+
+    TCP_BACKLOG
+            ("org.kaazing.gateway.server.transport.tcp.BACKLOG"),
+
+    TCP_KEEP_ALIVE
+            ("org.kaazing.gateway.server.transport.tcp.KEEP_ALIVE"),
+
+    TCP_RECEIVE_BUFFER_SIZE
+            ("org.kaazing.gateway.server.transport.tcp.RECEIVE_BUFFER_SIZE"),
+
+    TCP_SEND_BUFFER_SIZE
+            ("org.kaazing.gateway.server.transport.tcp.SEND_BUFFER_SIZE"),
+
+    TCP_SO_LINGER
+            ("org.kaazing.gateway.server.transport.tcp.SO_LINGER"),
+
+    TCP_IP_TOS
+            ("org.kaazing.gateway.server.transport.tcp.IP_TOS"),
 
     // services
-    BROADCAST_SERVICE_MAXIMUM_PENDING_BYTES("org.kaazing.gateway.server.service.broadcast.MAXIMUM_PENDING_BYTES"),
-    BROADCAST_SERVICE_DISCONNECT_CLIENTS_ON_RECONNECT("org.kaazing.gateway.server.service.broadcast.DISCONNECT_CLIENTS_ON_RECONNECT"), // true or false
+    BROADCAST_SERVICE_MAXIMUM_PENDING_BYTES
+            ("org.kaazing.gateway.server.service.broadcast.MAXIMUM_PENDING_BYTES"),
+
+    BROADCAST_SERVICE_DISCONNECT_CLIENTS_ON_RECONNECT
+            ("org.kaazing.gateway.server.service.broadcast.DISCONNECT_CLIENTS_ON_RECONNECT"), // true or false
 
     // management
-    MANAGEMENT_SESSION_THRESHOLD("org.kaazing.gateway.management.SESSION_THRESHOLD", "500");
-    
+    MANAGEMENT_SESSION_THRESHOLD
+            ("org.kaazing.gateway.management.SESSION_THRESHOLD", "500");
+
     private final String name;
     private final String defaultValue;
 
@@ -90,10 +125,10 @@ public enum InternalSystemProperty {
 
     public String getPropertyName() {
         return name;
-	}
-	
-	public boolean isSet(Properties configuration) {
-	    return configuration.containsKey(name);
-	}
+    }
+
+    public boolean isSet(Properties configuration) {
+        return configuration.containsKey(name);
+    }
 
 }

--- a/src/main/java/org/kaazing/gateway/util/Utils.java
+++ b/src/main/java/org/kaazing/gateway/util/Utils.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -55,17 +55,16 @@ import javax.annotation.Resource;
 import org.apache.mina.filter.logging.LogLevel;
 import org.slf4j.Logger;
 
-/**
- * 
- */
-/**
- * 
- */
+
 public final class Utils {
+
+    private Utils() {
+    }
+
     public static final Charset UTF_8 = Charset.forName("UTF-8");
-    
+
     public static final Charset US_ASCII = Charset.forName("US-ASCII");
-    
+
     private static final byte[] LONG_MIN_VALUE_BYTES = "-9223372036854775808".getBytes(UTF_8);
 
     private static final int LONG_MIN_VALUE_BYTES_LENGTH = LONG_MIN_VALUE_BYTES.length;
@@ -74,60 +73,75 @@ public final class Utils {
 
     private static final int INTEGER_MIN_VALUE_BYTES_LENGTH = INTEGER_MIN_VALUE_BYTES.length;
 
-    private static final Pattern TIME_INTERVAL_PATTERN = Pattern.compile("([0-9\\.]+)\\s*(?i:(ms|milli|millis|millisecond|milliseconds|s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hour|hours)?)");
+    private static final String TIME_UNIT_REGEX_STRING =
+            "(?i:(ms|milli|millis|millisecond|milliseconds|s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hour|hours)?)";
 
-    public static final Set<String> SECONDS_UNITS = new HashSet<String>(Arrays.asList("s", "sec", "secs", "second", "seconds"));
+    private static final String TIME_INTERVAL_REGEX_STRING = "([0-9\\.]+)\\s*" + TIME_UNIT_REGEX_STRING;
 
-    public static final Set<String> MILLISECONDS_UNITS = new HashSet<String>(Arrays.asList("ms", "milli", "millis", "millisecond", "milliseconds"));
+    private static final Pattern TIME_INTERVAL_PATTERN = Pattern.compile(TIME_INTERVAL_REGEX_STRING);
 
-    public static final Set<String> MINUTES_UNITS = new HashSet<String>(Arrays.asList("m", "min", "mins", "minute", "minutes"));
+    public static final Set<String> SECONDS_UNITS =
+            new HashSet<>(Arrays.asList("s", "sec", "secs", "second", "seconds"));
 
-    public static final Set<String> HOURS_UNITS = new HashSet<String>(Arrays.asList("h","hour","hours"));
-    
-    private static final String[] PERMITTED_DATA_RATE_UNITS = new String[] {"MiB/s", "KiB/s", "MB/s", "kB/s", "B/s"};
+    public static final Set<String> MILLISECONDS_UNITS =
+            new HashSet<>(Arrays.asList("ms", "milli", "millis", "millisecond", "milliseconds"));
+
+    public static final Set<String> MINUTES_UNITS =
+            new HashSet<>(Arrays.asList("m", "min", "mins", "minute", "minutes"));
+
+    public static final Set<String> HOURS_UNITS =
+            new HashSet<>(Arrays.asList("h", "hour", "hours"));
+
+    private static final String[] PERMITTED_DATA_RATE_UNITS =
+            new String[] {"MiB/s", "KiB/s", "MB/s", "kB/s", "B/s"};
+
     // The following must match the above by position:
-    private static final long[] DATA_RATE_MULTIPLIERS = new long[]{1024*1024, 1024, 1000*1000, 1000, 1};
+    private static final long[] DATA_RATE_MULTIPLIERS =
+            new long[]{1024 * 1024, 1024, 1000 * 1000, 1000, 1};
 
 
-    public static final String join(String[] array, String separator) {
+    public static String join(String[] array, String separator) {
         if (array == null) {
             throw new NullPointerException("array");
         }
-        
+
         if (separator == null) {
             throw new NullPointerException("separator");
         }
-        
+
         StringBuilder sb = new StringBuilder();
-        for (int i=0; i < array.length; i++) {
+        for (int i = 0; i < array.length; i++) {
             if (i > 0) {
                 sb.append(separator);
             }
             sb.append(array[i]);
         }
-        
+
         return sb.toString();
     }
-    
+
     /**
      * Creates a new String filled with size of a repeating character
-     * 
+     *
      * @param c Character to repeat
      * @param size Size of resulting String
      * @return String full of repeated characters
      */
-    public static final String fill(char c, int size) {
+    public static String fill(char c, int size) {
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < size; i++) {
             builder.append(c);
         }
         return builder.toString();
     }
-    
-    private static final byte[] TO_HEX = new byte[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
-  private static final byte[] FROM_HEX = new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
 
-    public static final String toHex(byte[] data) {
+    private static final byte[] TO_HEX =
+            new byte[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+
+  private static final byte[] FROM_HEX =
+          new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+
+    public static String toHex(byte[] data) {
         int len = data.length;
         byte[] out = new byte[len << 1];
         byte cur = 0;
@@ -161,7 +175,7 @@ public final class Utils {
         return 0x00;
     }
 
-    public static final byte[] fromHex(String hex) {
+    public static byte[] fromHex(String hex) {
 
         final int len = hex.length();
         byte[] out = new byte[len >> 1];
@@ -170,38 +184,38 @@ public final class Utils {
 
             final byte i1 = hexCharToByte(chars[i << 1]);
             final byte i2 = hexCharToByte(chars[(i << 1) + 1]);
-            out[i] =(byte) (  (i1<<4) + i2);
+            out[i] = (byte) ((i1 << 4) + i2);
 
         }
         return out;
     }
 
     public static int ENCODED_BOOLEAN_CAPACITY = 4;
-    
+
     public static void encodeBoolean(boolean b, ByteBuffer buf) {
         buf.put(b ? TRUE_BYTES : FALSE_BYTES);
     }
-    
+
     public static int ENCODED_INT_CAPACITY = INTEGER_MIN_VALUE_BYTES_LENGTH;
-    
+
     public static void encodeInt(int i, ByteBuffer buf) {
         if (i == Integer.MIN_VALUE) {
             buf.put(INTEGER_MIN_VALUE_BYTES);
         }
-        
+
         int size = (i < 0) ? stringSize(-i) + 1 : stringSize(i);
         if (buf.remaining() < size) {
             throw new BufferUnderflowException();
         }
-        
+
         int position = buf.position();
         int offset = position + size;
-        
+
         int q, r;
         byte sign = 0;
 
         int positive = i;
-        if (positive < 0) { 
+        if (positive < 0) {
             sign = '-';
             positive = -positive;
         }
@@ -218,27 +232,29 @@ public final class Utils {
 
         // Fall thru to fast mode for smaller numbers
         // assert(i <= 65536, i);
-        for (;;) { 
-            q = (positive * 52429) >>> (16+3);
+        for (;;) {
+            q = (positive * 52429) >>> (16 + 3);
             r = positive - ((q << 3) + (q << 1));  // r = i-(q*10) ...
             buf.put(--offset, digits[r]);
             positive = q;
-            if (positive == 0) break;
+            if (positive == 0) {
+                break;
+            }
         }
         if (sign != 0) {
             buf.put(--offset, sign);
         }
-        
+
         buf.position(position + size);
     }
-    
+
     public static int ENCODED_LONG_CAPACITY = LONG_MIN_VALUE_BYTES_LENGTH;
-    
+
     public static void encodeLong(long i, ByteBuffer buf) {
         if (i == Long.MIN_VALUE) {
             buf.put(LONG_MIN_VALUE_BYTES);
         }
-        
+
         int size = (i < 0) ? stringSize(-i) + 1 : stringSize(i);
         if (buf.remaining() < size) {
             throw new BufferUnderflowException();
@@ -258,10 +274,10 @@ public final class Utils {
         }
 
         // Get 2 digits/iteration using longs until quotient fits into an int
-        while (positive > Integer.MAX_VALUE) { 
+        while (positive > Integer.MAX_VALUE) {
             q = positive / 100;
             // really: r = i - (q * 100);
-            r = (int)(positive - ((q << 6) + (q << 5) + (q << 2)));
+            r = (int) (positive - ((q << 6) + (q << 5) + (q << 2)));
             positive = q;
             buf.put(--offset, DigitOnes[r]);
             buf.put(--offset, DigitTens[r]);
@@ -269,7 +285,7 @@ public final class Utils {
 
         // Get 2 digits/iteration using ints
         int q2;
-        int i2 = (int)positive;
+        int i2 = (int) positive;
         while (i2 >= 65536) {
             q2 = i2 / 100;
             // really: r = i2 - (q * 100);
@@ -282,27 +298,30 @@ public final class Utils {
         // Fall thru to fast mode for smaller numbers
         // assert(i2 <= 65536, i2);
         for (;;) {
-            q2 = (i2 * 52429) >>> (16+3);
+            q2 = (i2 * 52429) >>> (16 + 3);
             r = i2 - ((q2 << 3) + (q2 << 1));  // r = i2-(q2*10) ...
             buf.put(--offset, digits[r]);
             i2 = q2;
-            if (i2 == 0) break;
+            if (i2 == 0) {
+                break;
+            }
         }
         if (sign != 0) {
             buf.put(--offset, sign);
         }
-        
+
         buf.position(position + size);
     }
 
-    public static final String asString(Map<ByteBuffer, ByteBuffer> headers) {
+    public static String asString(Map<ByteBuffer, ByteBuffer> headers) {
         if (headers == null) {
             return null;
         }
-        
-        Iterator<Entry<ByteBuffer,ByteBuffer>> i = headers.entrySet().iterator();
-        if (! i.hasNext())
+
+        Iterator<Entry<ByteBuffer, ByteBuffer>> i = headers.entrySet().iterator();
+        if (! i.hasNext()) {
             return "{}";
+        }
 
         StringBuilder sb = new StringBuilder();
         sb.append('{');
@@ -313,17 +332,18 @@ public final class Utils {
             sb.append(key   == headers ? "(this Map)" : asString(key));
             sb.append('=');
             sb.append(value == headers ? "(this Map)" : asString(value));
-            if (! i.hasNext())
-            return sb.append('}').toString();
+            if (! i.hasNext()) {
+                return sb.append('}').toString();
+            }
             sb.append(", ");
         }
     }
-    
+
     /**
      * @param  buf         UTF-8 encoded bytes
      * @return String      UTF-8 decoded result
      */
-    public static final String asString(ByteBuffer buf) {
+    public static String asString(ByteBuffer buf) {
         if (buf == null) {
             return null;
         }
@@ -342,12 +362,12 @@ public final class Utils {
             throw new RuntimeException(e);
         }
     }
-    
+
     /**
      * Gets the content of the ByteBuffer as a byte[] without mutating the buffer
      * (so thread safe) and minimizing GC (i.e. object creation)
      */
-    public static final byte[] asByteArray(ByteBuffer buf) {
+    public static byte[] asByteArray(ByteBuffer buf) {
         byte[] result = null;
         if (buf.hasArray() && buf.arrayOffset() == 0 && buf.capacity() == buf.remaining()) {
             result = buf.array();
@@ -367,58 +387,58 @@ public final class Utils {
         }
         return result;
     }
-    
+
     @Deprecated // Use asString now it's been fixed to use UTF-8 CharSet
-    public static final String asStringUTF8(ByteBuffer buf) {
+    public static String asStringUTF8(ByteBuffer buf) {
         return asString(buf);
     }
-    
-    public static final ByteBuffer asByteBuffer(String s) {
-        if(null == s ) {
+
+    public static ByteBuffer asByteBuffer(String s) {
+        if (null == s) {
             return null;
         }
-        if(s.length() < 1024) { // we will only check isASCII if message less then 1K.
+        if (s.length() < 1024) { // we will only check isASCII if message less then 1K.
             return isASCII(s) ? US_ASCII.encode(s) : UTF_8.encode(s);
         } else {
-            return UTF_8.encode(s);  
+            return UTF_8.encode(s);
         }
     }
-    
-    public static final boolean isASCII(String s) {
+
+    public static boolean isASCII(String s) {
         int size = s.length();
         char c;
         for (int i = 0; i < size; i++) {
             c = s.charAt(i);
-            if(!(c >= 0 && c <= 127)) {
+            if (!(c >= 0 && c <= 127)) {
                 return false;
             }
         }
         return true;
     }
-    
-    public static final ByteBuffer asByteBuffer(byte[] bytes) {
+
+    public static ByteBuffer asByteBuffer(byte[] bytes) {
         return (bytes != null) ? ByteBuffer.wrap(bytes) : null;
     }
-    
+
     /**
      * Reads an int value from the buffer starting at the given index relative to the current
-     * position() of the buffer, without mutating the buffer in any way (so it's thread safe). 
+     * position() of the buffer, without mutating the buffer in any way (so it's thread safe).
      */
     public static int getInt(ByteBuffer buf, int index) {
         return buf.order() == BIG_ENDIAN ? getIntB(buf, index) : getIntL(buf, index);
     }
-    
+
     /**
      * Reads an long value from the buffer starting at the given index relative to the current
-     * position() of the buffer, without mutating the buffer in any way (so it's thread safe). 
+     * position() of the buffer, without mutating the buffer in any way (so it's thread safe).
      */
     public static long getLong(ByteBuffer buf, int index) {
         return buf.order() == BIG_ENDIAN ? getLongB(buf, index) : getLongL(buf, index);
     }
-    
+
     /**
      * Reads a short value from the buffer starting at the given index relative to the current
-     * position() of the buffer, without mutating the buffer in any way (so it's thread safe). 
+     * position() of the buffer, without mutating the buffer in any way (so it's thread safe).
      */
     public static short getShort(ByteBuffer buf, int index) {
         return buf.order() == BIG_ENDIAN ? getShortB(buf, index) : getShortL(buf, index);
@@ -429,7 +449,7 @@ public final class Utils {
      * multithreaded access to source) and without GC (unless source is a direct buffer).
      */
     public static void putByteBuffer(ByteBuffer source, ByteBuffer target) {
-        if ( source.hasArray() ) {
+        if (source.hasArray()) {
             byte[] array = source.array();
             int arrayOffset = source.arrayOffset();
             target.put(array, arrayOffset + source.position(), source.remaining());
@@ -438,22 +458,22 @@ public final class Utils {
             target.put(source.duplicate());
         }
     }
-    
+
     /**
      * Load the specified class, which can be a (public static) inner class provided the physical name is used
      * ("my.package.MyClass$MyInnerClass") rather than the canonical name ("my.package.MyClass.MyInnerClass")
      * @param className Fully qualified class name
-     * @return The loaded Class 
+     * @return The loaded Class
      * @throws ClassNotFoundException
      * @throws NoSuchFieldException
      * @throws IllegalAccessException
      */
-    public static Class<?> loadClass(String className) 
+    public static Class<?> loadClass(String className)
     throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
       ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
       return classLoader.loadClass(className);
     }
-    
+
     /**
      * Gets the value of a static int field (static final constant), given its fully qualified name.
      * The owner class can be a (public static) inner class provided the physical name is used
@@ -462,24 +482,24 @@ public final class Utils {
      * @return the value of the field
      * @throws ClassNotFoundException
      * @throws NoSuchFieldException
-     * @throws IllegalAccessException 
-     * @throws IllegalArgumentException - if the given name is invalid 
+     * @throws IllegalAccessException
+     * @throws IllegalArgumentException - if the given name is invalid
      */
-    public static int loadStaticInt(String fullyQualifiedFieldName) 
+    public static int loadStaticInt(String fullyQualifiedFieldName)
       throws ClassNotFoundException, NoSuchFieldException, IllegalAccessException {
         int lastDotPos = fullyQualifiedFieldName.lastIndexOf('.');
         // Name must contain "." but not as first or last character
-        if ( lastDotPos <= 0 || lastDotPos+1 >= fullyQualifiedFieldName.length() ) {
+        if (lastDotPos <= 0 || lastDotPos + 1 >= fullyQualifiedFieldName.length()) {
             throw new IllegalArgumentException(fullyQualifiedFieldName);
         }
         String className = fullyQualifiedFieldName.substring(0, lastDotPos);
-        String fieldName = fullyQualifiedFieldName.substring(lastDotPos+1);
+        String fieldName = fullyQualifiedFieldName.substring(lastDotPos + 1);
         Class<?> clazz = loadClass(className);
         Field field = clazz.getField(fieldName);
         int mode = field.getInt(clazz);
         return mode;
     }
-    
+
     /**
      * Validate that the given string value is a valid boolean ("true" or "false", case insensitive) and convert it to a boolean
      * @param valueName
@@ -490,7 +510,7 @@ public final class Utils {
      */
     public static boolean parseBoolean(String valueName, String value, boolean defaultValue) {
         boolean result = defaultValue;
-        if ( value != null ) {
+        if (value != null) {
             boolean valid = true;
             result = Boolean.parseBoolean(value);
             // parseBoolean allows any value, e.g. so a typo like "trye" would be silently interpreted as false
@@ -499,7 +519,7 @@ public final class Utils {
                     valid = false;
                 }
             }
-            if ( !valid ) {
+            if (!valid) {
                 String message = String.format("Invalid value \"%s\" for %s, must be \"%s\" or \"%s\"",
                         value, valueName, Boolean.TRUE.toString(), Boolean.FALSE.toString());
                 throw new IllegalArgumentException(message);
@@ -507,7 +527,7 @@ public final class Utils {
         }
         return result;
     }
-    
+
     /**
      * Validate that the given string value is a valid positive integer (int or long) and convert it to a long
      * @param valueName
@@ -518,18 +538,18 @@ public final class Utils {
      */
     public static long parsePositiveInteger(String valueName, String value, long defaultValue) {
         long result = defaultValue;
-        if ( value != null ) {
+        if (value != null) {
             boolean valid = true;
             try {
                 result = Long.parseLong(value);
-                if ( result <= 0 ) {
+                if (result <= 0) {
                     valid = false;
                 }
             }
             catch (NumberFormatException e) {
                 valid = false;
             }
-            if ( !valid ) {
+            if (!valid) {
                 String message = String.format("Invalid value \"%s\" for %s, must be a positive integer",
                         value, valueName);
                 throw new IllegalArgumentException(message);
@@ -551,7 +571,7 @@ public final class Utils {
     public static long parseTimeInterval(String timeIntervalValue, TimeUnit outputUnit, long defaultValue) {
         return parseTimeInterval(timeIntervalValue, outputUnit, String.valueOf(defaultValue) + "seconds");
     }
-    
+
     /**
      * @param timeIntervalValue - The value to be passed
      * @param outputUnit        - The value will be converted to this unit
@@ -561,61 +581,66 @@ public final class Utils {
      */
     public static long parseTimeInterval(String timeIntervalValue, TimeUnit outputUnit, String defaultValue) {
         outputUnit = outputUnit == null ? TimeUnit.SECONDS : outputUnit;
-        if ( timeIntervalValue == null ) {
+        if (timeIntervalValue == null) {
             return parseTimeInterval(defaultValue, outputUnit, 0);
         }
-        if ( outputUnit == null ) {
+        if (outputUnit == null) {
             return parseTimeInterval(String.valueOf(timeIntervalValue), TimeUnit.SECONDS, 0);
         }
 
         int length = timeIntervalValue.length();
-        if ( length < 1 ) {
-            throw new NumberFormatException("Illegal timeInterval value, empty string not allowed.\n"+TIME_INTERVAL_INFORMATION);
+        if (length < 1) {
+            throw new NumberFormatException("Illegal timeInterval value, empty string not allowed.\n"
+                    + TIME_INTERVAL_INFORMATION);
         }
 
         Matcher matcher = TIME_INTERVAL_PATTERN.matcher(timeIntervalValue);
-        if ( matcher.matches()) {
+        if (matcher.matches()) {
             String unit = "seconds";
             double providedMultiplier = Double.parseDouble(matcher.group(1));
-            if ( providedMultiplier < 0 ) {
-                throw new NumberFormatException("Illegal timeInterval value, negative intervals not allowed.\n"+TIME_INTERVAL_INFORMATION);
+            if (providedMultiplier < 0) {
+                throw new NumberFormatException("Illegal timeInterval value, negative intervals not allowed.\n"
+                        + TIME_INTERVAL_INFORMATION);
             }
-            if ( matcher.group(2) != null) {
+            if (matcher.group(2) != null) {
                 unit = matcher.group(2);
             }
 
             long result = 1L;
 
             try {
-                if ( SECONDS_UNITS.contains(unit.toLowerCase()) ) {
-                    result = (long)(providedMultiplier*outputUnit.convert(result, TimeUnit.SECONDS));
-                } else if ( MILLISECONDS_UNITS.contains(unit.toLowerCase()) ) {
-                    result = (long)(providedMultiplier*outputUnit.convert(result, TimeUnit.MILLISECONDS));
-                } else if ( MINUTES_UNITS.contains(unit.toLowerCase())) {
-                    result = (long)(providedMultiplier*outputUnit.convert(result, TimeUnit.MINUTES));
-                } else if ( HOURS_UNITS.contains(unit.toLowerCase())) {
-                    result = (long)(providedMultiplier*outputUnit.convert(result, TimeUnit.HOURS));
+                if (SECONDS_UNITS.contains(unit.toLowerCase())) {
+                    result = (long) (providedMultiplier * outputUnit.convert(result, TimeUnit.SECONDS));
+                } else if (MILLISECONDS_UNITS.contains(unit.toLowerCase())) {
+                    result = (long) (providedMultiplier * outputUnit.convert(result, TimeUnit.MILLISECONDS));
+                } else if (MINUTES_UNITS.contains(unit.toLowerCase())) {
+                    result = (long) (providedMultiplier * outputUnit.convert(result, TimeUnit.MINUTES));
+                } else if (HOURS_UNITS.contains(unit.toLowerCase())) {
+                    result = (long) (providedMultiplier * outputUnit.convert(result, TimeUnit.HOURS));
                 }
-                if ( result < 0) {
-                    throw new NumberFormatException("Expected a non-negative time interval, received \""+timeIntervalValue+"\"");
+                if (result < 0) {
+                    throw new NumberFormatException("Expected a non-negative time interval, received \""
+                            + timeIntervalValue + "\"");
                 }
                 return result;
             } catch (Exception e) {
                 throw (NumberFormatException)
                         new NumberFormatException("Illegal timeIntervalValue value \"" +
-                                timeIntervalValue + "\".\n"+TIME_INTERVAL_INFORMATION).initCause(e);
+                                timeIntervalValue + "\".\n" + TIME_INTERVAL_INFORMATION).initCause(e);
             }
         } else {
-            throw new NumberFormatException("Illegal timeIntervalValue value \"" + timeIntervalValue + "\".\n"+TIME_INTERVAL_INFORMATION);
+            throw new NumberFormatException("Illegal timeIntervalValue value \"" + timeIntervalValue + "\".\n"
+                    + TIME_INTERVAL_INFORMATION);
         }
     }
 
     private static String TIME_INTERVAL_INFORMATION =
-            "Time intervals can be specified as numeric amounts of the following units: millisecond, second, minute, hour.\nFor example, \"1800 second\" or \"30 minutes\" or \"0.5 hour\".";
+            "Time intervals can be specified as numeric amounts of the following units: millisecond, second, minute, hour.\n" +
+                    "For example, \"1800 second\" or \"30 minutes\" or \"0.5 hour\".";
     /**
-     * Converts a data size specified in bytes (all digits), kilobytes (digits followed by k or K) 
+     * Converts a data size specified in bytes (all digits), kilobytes (digits followed by k or K)
      * or megabytes (digits followed by m or M), values like 1048, 64k, 10M.
-     * @param dataSizeValue   data size 
+     * @param dataSizeValue   data size
      * @return - data size converted to int number of bytes
      */
     public static int parseDataSize(String dataSizeValue) {
@@ -624,45 +649,46 @@ public final class Utils {
 
     /**
      * Converts a per second data rate specified in bytes (all digits), decimal kilobytes (digits followed by kB/s),
-     * binary kilobytes (digits followed by KiB/s), decimal megabytes (digits followed by MB/s), or 
+     * binary kilobytes (digits followed by KiB/s), decimal megabytes (digits followed by MB/s), or
      * binary megabytes (digits followed by KiB/s), values like 1048, 64kB/s, 10MiB/s.
      * @param dataRateValue   data size
      * @return - data rate converted to int number of bytes (implicitly per second)
      */
     public static long parseDataRate(String dataRateValue) {
         int length = dataRateValue.length();
-        if ( length < 1 ) {
+        if (length < 1) {
             throw new NumberFormatException("Illegal dataRate value, empty string not allowed");
         }
-        char last = dataRateValue.charAt(length-1);
+        char last = dataRateValue.charAt(length - 1);
         long multiplier = 1;
         String numberPart = dataRateValue;
         if (!Character.isDigit(last)) {
-            for (int i=0; i<PERMITTED_DATA_RATE_UNITS.length; i++) {
+            for (int i = 0; i < PERMITTED_DATA_RATE_UNITS.length; i++) {
                 if (dataRateValue.endsWith(PERMITTED_DATA_RATE_UNITS[i])) {
                     multiplier = DATA_RATE_MULTIPLIERS[i];
                     int unitLength = PERMITTED_DATA_RATE_UNITS[i].length();
-                    if (length < (unitLength+1)) {
+                    if (length < (unitLength + 1)) {
                         throw new NumberFormatException("Invalid dataRate value \"" + dataRateValue + "\", number part missing");
                     }
-                    numberPart  = dataRateValue.substring(0, length-unitLength);
+                    numberPart  = dataRateValue.substring(0, length - unitLength);
                     break;
                 }
             }
         }
         final long result = Long.parseLong(numberPart) * multiplier;
-        if ( result <= 0 ) {
-            throw new NumberFormatException("Illegal dataRate value \"" + dataRateValue + "\", must be a positive number or overflow occurred");
+        if (result <= 0) {
+            throw new NumberFormatException("Illegal dataRate value \"" + dataRateValue +
+                    "\", must be a positive number or overflow occurred");
         }
         return result;
     }
 
     private static int parseDataSize(String dataSizeValue, String specifier) {
         int length = dataSizeValue.length();
-        if ( length < 1 ) {
-            throw new NumberFormatException("Illegal "+specifier+" value, empty string not allowed");
+        if (length < 1) {
+            throw new NumberFormatException("Illegal " + specifier + " value, empty string not allowed");
         }
-        char last = dataSizeValue.charAt(length-1); 
+        char last = dataSizeValue.charAt(length - 1);
         int multiplier = 1;
         String numberPart = dataSizeValue;
         switch(last) {
@@ -672,41 +698,41 @@ public final class Utils {
                 break;
             case 'm':
             case 'M':
-                multiplier = 1024*1024;
+                multiplier = 1024 * 1024;
                 break;
         }
         if (multiplier > 1) {
             if (length < 2) {
-               throw new NumberFormatException("Illegal "+specifier+" value \"" + dataSizeValue + "\", number part missing");
+               throw new NumberFormatException("Illegal " + specifier + " value \"" + dataSizeValue + "\", number part missing");
             }
             else {
-                numberPart  = dataSizeValue.substring(0, length-1);
+                numberPart  = dataSizeValue.substring(0, length - 1);
             }
         }
         final int result = Integer.parseInt(numberPart) * multiplier;
         return result;
     }
-    
-    public static final boolean sameOrEquals(Object this_, Object that) {
+
+    public static boolean sameOrEquals(Object this_, Object that) {
         return (this_ == that) || (this_ != null && this_.equals(that));
     }
-    
-    public static final <K, V> boolean sameOrEquals(Map<K, V> this_, Map<K, V> that) {
-        return (this_ == that) || 
-                (this_ == null && that.isEmpty()) || (that == null && this_.isEmpty()) || 
+
+    public static <K, V> boolean sameOrEquals(Map<K, V> this_, Map<K, V> that) {
+        return (this_ == that) ||
+                (this_ == null && that.isEmpty()) || (that == null && this_.isEmpty()) ||
                 (this_ != null && this_.equals(that));
     }
-    
-    public static final <T> boolean sameOrEquals(Collection<T> this_, Collection<T> that) {
-        return (this_ == that) || 
-                (this_ == null && that.isEmpty()) || (that == null && this_.isEmpty()) || 
+
+    public static <T> boolean sameOrEquals(Collection<T> this_, Collection<T> that) {
+        return (this_ == that) ||
+                (this_ == null && that.isEmpty()) || (that == null && this_.isEmpty()) ||
                 (this_ != null && this_.equals(that));
     }
-    
+
     private static final byte[] TRUE_BYTES = "true".getBytes(UTF_8);
     private static final byte[] FALSE_BYTES = "false".getBytes(UTF_8);
-    
-    final static byte[] digits = {
+
+    static final byte[] digits = {
         '0' , '1' , '2' , '3' , '4' , '5' ,
         '6' , '7' , '8' , '9' , 'a' , 'b' ,
         'c' , 'd' , 'e' , 'f' , 'g' , 'h' ,
@@ -715,7 +741,7 @@ public final class Utils {
         'u' , 'v' , 'w' , 'x' , 'y' , 'z'
         };
 
-    final static byte[] DigitTens = {
+    static final byte[] DigitTens = {
         '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
         '1', '1', '1', '1', '1', '1', '1', '1', '1', '1',
         '2', '2', '2', '2', '2', '2', '2', '2', '2', '2',
@@ -726,9 +752,9 @@ public final class Utils {
         '7', '7', '7', '7', '7', '7', '7', '7', '7', '7',
         '8', '8', '8', '8', '8', '8', '8', '8', '8', '8',
         '9', '9', '9', '9', '9', '9', '9', '9', '9', '9',
-        } ; 
+        } ;
 
-    final static byte[] DigitOnes = { 
+    static final byte[] DigitOnes = {
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
@@ -741,29 +767,32 @@ public final class Utils {
         '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
         } ;
 
-    final static int [] sizeTable = { 9, 99, 999, 9999, 99999, 999999, 9999999,
+    static final int [] sizeTable = { 9, 99, 999, 9999, 99999, 999999, 9999999,
         99999999, 999999999, Integer.MAX_VALUE };
 
     // Requires positive x
     static int stringSize(int x) {
-        for (int i = 0;; i++)
-            if (x <= sizeTable[i])
+        for (int i = 0;; i++) {
+            if (x <= sizeTable[i]) {
                 return i + 1;
+            }
+        }
     }
 
     static int stringSize(long x) {
         long p = 10;
-        for (int i=1; i<19; i++) {
-            if (x < p)
+        for (int i = 1; i < 19; i++) {
+            if (x < p) {
                 return i;
-            p = 10*p;
+            }
+            p = 10 * p;
         }
         return 19;
     }
 
     private static final Random rand = new SecureRandom();
-    
-    public static final String randomHexString(int len) {
+
+    public static String randomHexString(int len) {
         byte[] out = randomHexBytes(len);
         return new String(out);
     }
@@ -776,12 +805,12 @@ public final class Utils {
         }
         return out;
     }
-    
-    public static final int randomInt() {
+
+    public static int randomInt() {
         return rand.nextInt();
     }
-    
-    public static final void log(Logger logger, LogLevel eventLevel, String message, Throwable cause) {
+
+    public static void log(Logger logger, LogLevel eventLevel, String message, Throwable cause) {
         switch (eventLevel) {
             case TRACE : logger.trace(message, cause); return;
             case DEBUG : logger.debug(message, cause); return;
@@ -792,7 +821,7 @@ public final class Utils {
         }
     }
 
-    public static final void log(Logger logger, LogLevel eventLevel, String message, Object param) {
+    public static void log(Logger logger, LogLevel eventLevel, String message, Object param) {
         switch (eventLevel) {
             case TRACE : logger.trace(message, param); return;
             case DEBUG : logger.debug(message, param); return;
@@ -803,7 +832,7 @@ public final class Utils {
         }
     }
 
-    public static final void log(Logger logger, LogLevel eventLevel, String message, Object param1, Object param2) {
+    public static void log(Logger logger, LogLevel eventLevel, String message, Object param1, Object param2) {
         switch (eventLevel) {
             case TRACE : logger.trace(message, param1, param2); return;
             case DEBUG : logger.debug(message, param1, param2); return;
@@ -814,7 +843,7 @@ public final class Utils {
         }
     }
 
-    public static final void log(Logger logger, LogLevel eventLevel, String message, Object param1, Object param2, Object param3) {
+    public static void log(Logger logger, LogLevel eventLevel, String message, Object param1, Object param2, Object param3) {
         switch (eventLevel) {
             case TRACE : logger.trace(message, new Object[] { param1, param2, param3 }); return;
             case DEBUG : logger.debug(message, new Object[] { param1, param2, param3 }); return;
@@ -828,16 +857,16 @@ public final class Utils {
     public static <T> void inject(Object target,
                                   Class<T> injectableType,
                                   T injectableInstance) {
-    	inject0(target, injectableType, injectableInstance);
+        inject0(target, injectableType, injectableInstance);
     }
 
     private static void inject0(Object target,
             Class<?> injectableType,
             Object injectableInstance) {
 
-    	Class<? extends Object> targetClass = target.getClass();
-    	Method[] methods = targetClass.getMethods();
-    	for (Method method : methods) {
+        Class<? extends Object> targetClass = target.getClass();
+        Method[] methods = targetClass.getMethods();
+        for (Method method : methods) {
             String methodName = method.getName();
             Class<?>[] parameterTypes = method.getParameterTypes();
             if (methodName.startsWith("set") &&
@@ -873,27 +902,27 @@ public final class Utils {
         }
     }
 
-	public static void injectAll(Object target, Map<Class<?>, Object> injectables) {
+    public static void injectAll(Object target, Map<Class<?>, Object> injectables) {
 
-		for (Map.Entry<Class<?>, Object> entry : injectables.entrySet()) {
-			Class<?> injectableType = entry.getKey();
-			Object injectableInstance = entry.getValue();
-			inject0(target, injectableType, injectableInstance);
-		}
-	}
+        for (Map.Entry<Class<?>, Object> entry : injectables.entrySet()) {
+            Class<?> injectableType = entry.getKey();
+            Object injectableInstance = entry.getValue();
+            inject0(target, injectableType, injectableInstance);
+        }
+    }
 
     public static String join(Object[] data, String separator) {
-		int len = data.length;
-		if (len == 0) {
-			return null;
-		}
-		StringBuilder buf = new StringBuilder();
-		buf.append(data[0].toString());
-		for (int i = 1; i < data.length; i++) {
-			buf.append(separator);
-			buf.append(data[i].toString());
-		}		
-		return buf.toString();
+        int len = data.length;
+        if (len == 0) {
+            return null;
+        }
+        StringBuilder buf = new StringBuilder();
+        buf.append(data[0].toString());
+        for (int i = 1; i < data.length; i++) {
+            buf.append(separator);
+            buf.append(data[i].toString());
+        }
+        return buf.toString();
     }
 
     public static String asCommaSeparatedString(final Collection<String> strings) {
@@ -904,28 +933,30 @@ public final class Utils {
 
     public static String asSeparatedString(final Collection<String> strings, final String separator) {
             StringBuilder b = new StringBuilder();
-            if (  strings != null ) {
+            if (strings != null) {
                 for (String protocol: strings) {
                     b.append(protocol).append(separator);
                 }
-                if ( strings.size() > 0 ) {
-                    b.deleteCharAt(b.length()-1);
+                if (strings.size() > 0) {
+                    b.deleteCharAt(b.length() - 1);
                 }
             }
             return b.toString();
         }
 
-    public static Map<String,Object> rewriteKeys(final Map<String,Object> options, String prefix, String newPrefix) {
+    public static Map<String, Object> rewriteKeys(final Map<String, Object> options, String prefix, String newPrefix) {
         final String separator = ".";
-        final String startWith = prefix+separator;
+        final String startWith = prefix + separator;
         final int startWithLength = startWith.length();
-        if ( options == null) return null;
-        Map<String,Object> result = new HashMap<String,Object>(options);
-        for ( Entry<String,Object> e: options.entrySet()) {
-            if ( e.getKey().startsWith(startWith)) {
-                String newKey = newPrefix+separator;
+        if (options == null) {
+            return null;
+        }
+        Map<String, Object> result = new HashMap<>(options);
+        for (Entry<String, Object> e: options.entrySet()) {
+            if (e.getKey().startsWith(startWith)) {
+                String newKey = newPrefix + separator;
                 final String suffix = e.getKey().substring(startWithLength);
-                result.put(newKey+suffix, result.remove(e.getKey()));
+                result.put(newKey + suffix, result.remove(e.getKey()));
             }
         }
         return result;
@@ -941,7 +972,7 @@ public final class Utils {
      */
     public static String getHostStringWithoutNameLookup(InetSocketAddress inetSocketAddress) {
         String newHost;
-        if ( inetSocketAddress.isUnresolved() ) {
+        if (inetSocketAddress.isUnresolved()) {
             newHost = inetSocketAddress.getHostName();
         } else {
             newHost = inetSocketAddress.getAddress().getHostAddress();
@@ -956,32 +987,32 @@ public final class Utils {
         cause.printStackTrace(printStream);
         printStream.flush();
         return byteArrayOutputStream.toString();
-		
+
     }
-    
-    static private short makeShort(byte b1, byte b0) {
-        return (short)((b1 << 8) | (b0 & 0xff));
+
+    private static short makeShort(byte b1, byte b0) {
+        return (short) ((b1 << 8) | (b0 & 0xff));
     }
 
     static short getShortL(ByteBuffer bb, int bi) {
         return makeShort(bb.get(bi + 1),
-                         bb.get(bi    ));
+                         bb.get(bi));
     }
 
     static short getShortB(ByteBuffer bb, int bi) {
-        return makeShort(bb.get(bi    ),
+        return makeShort(bb.get(bi),
                          bb.get(bi + 1));
     }
-	
+
     private static int makeInt(byte b3, byte b2, byte b1, byte b0) {
-        return (((b3       ) << 24) |
-                ((b2 & 0xff) << 16) |
-                ((b1 & 0xff) <<  8) |
-                ((b0 & 0xff)      ));
+        return b3 << 24 |
+                (b2 & 0xff) << 16 |
+                (b1 & 0xff) <<  8 |
+                b0 & 0xff;
     }
 
     private static int getIntB(ByteBuffer bb, int index) {
-        return makeInt(bb.get(index    ),
+        return makeInt(bb.get(index),
                        bb.get(index + 1),
                        bb.get(index + 2),
                        bb.get(index + 3));
@@ -991,20 +1022,19 @@ public final class Utils {
         return makeInt(bb.get(index + 3),
                        bb.get(index + 2),
                        bb.get(index + 1),
-                       bb.get(index    ));
+                       bb.get(index));
     }
-    
+
     private static long makeLong(byte b7, byte b6, byte b5, byte b4,
-            byte b3, byte b2, byte b1, byte b0)
-    {       
-        return ((((long)b7       ) << 56) |
-                (((long)b6 & 0xff) << 48) |
-                (((long)b5 & 0xff) << 40) |
-                (((long)b4 & 0xff) << 32) |
-                (((long)b3 & 0xff) << 24) |
-                (((long)b2 & 0xff) << 16) |
-                (((long)b1 & 0xff) <<  8) |
-                (((long)b0 & 0xff)      ));
+            byte b3, byte b2, byte b1, byte b0) {
+        return (long) b7 << 56 |
+                ((long) b6 & 0xff) << 48 |
+                ((long) b5 & 0xff) << 40 |
+                ((long) b4 & 0xff) << 32 |
+                ((long) b3 & 0xff) << 24 |
+                ((long) b2 & 0xff) << 16 |
+                ((long) b1 & 0xff) <<  8 |
+                (long) b0 & 0xff;
     }
 
     private static long getLongL(ByteBuffer bb, int index) {
@@ -1015,11 +1045,11 @@ public final class Utils {
                         bb.get(index + 3),
                         bb.get(index + 2),
                         bb.get(index + 1),
-                        bb.get(index    ));
+                        bb.get(index));
     }
-    
+
     private static long getLongB(ByteBuffer bb, int index) {
-        return makeLong(bb.get(index    ),
+        return makeLong(bb.get(index),
                         bb.get(index + 1),
                         bb.get(index + 2),
                         bb.get(index + 3),
@@ -1039,20 +1069,20 @@ public final class Utils {
         int index = -1;
         for (int i = 0; i < option.length; i++) {
             String element = option[i];
-            if ( remove == null ) {
+            if (remove == null) {
                 if (element == null) {
                     index = i;
                     break;
                 }
             } else {
-                if ( remove.equals(element)) {
+                if (remove.equals(element)) {
                     index = i;
                 }
             }
         }
 
-        if ( index != -1 ) {
-            String[] result = new String[option.length-1];
+        if (index != -1) {
+            String[] result = new String[option.length - 1];
             System.arraycopy(option, 0, result, 0, index);
             System.arraycopy(option, index + 1, result, index, option.length - (index + 1));
             return result;

--- a/src/main/java/org/kaazing/gateway/util/asn1/Asn1Utils.java
+++ b/src/main/java/org/kaazing/gateway/util/asn1/Asn1Utils.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -45,7 +45,8 @@ public final class Asn1Utils {
     private static final int ASN1_IA5STRING_TAG_NUM = 27;
 
     // Generalized time format is yyyyMMddHHmmss[.[s]+][Z|[+-]zzzz]
-    private static final String GENERALIZED_TIME_REGEX = "(\\d{4})(\\d{2})(\\d{2})(\\d{2})(\\d{2})(\\d{2})(\\.\\d+)?(Z|[+-]\\d{4})?";
+    private static final String GENERALIZED_TIME_REGEX =
+            "(\\d{4})(\\d{2})(\\d{2})(\\d{2})(\\d{2})(\\d{2})(\\.\\d+)?(Z|[+-]\\d{4})?";
     private static final Pattern GENERALIZED_TIME_PATTERN = Pattern.compile(GENERALIZED_TIME_REGEX);
     private static final String GENERALIZED_TIME_FORMAT = "yyyyMMddHHmmss'Z'"; // always use UTC
 
@@ -53,7 +54,7 @@ public final class Asn1Utils {
 
     /**
      * Decode an ASN.1 BIT STRING.
-     * 
+     *
      * @param buf
      *            the buffer containing the DER-encoded BIT STRING.
      * @return the bits in the BIT STRING
@@ -93,7 +94,7 @@ public final class Asn1Utils {
 
     /**
      * Decode an ASN.1 GeneralizedTime.
-     * 
+     *
      * @param buf
      *            the DER-encoded GeneralizedTime
      * @return the data and time
@@ -148,7 +149,7 @@ public final class Asn1Utils {
 
     /**
      * Decode an ASN.1 IA5String.
-     * 
+     *
      * @param buf
      *            the DER-encoded IA5String
      * @return the string
@@ -169,7 +170,7 @@ public final class Asn1Utils {
 
     /**
      * Decode an ASN.1 INTEGER.
-     * 
+     *
      * @param buf
      *            the buffer containing the DER-encoded INTEGER
      * @return the value of the INTEGER
@@ -192,7 +193,7 @@ public final class Asn1Utils {
 
     /**
      * Decode an ASN.1 OCTET STRING.
-     * 
+     *
      * @param buf
      *            the DER-encoded OCTET STRING
      * @return the octets
@@ -215,7 +216,7 @@ public final class Asn1Utils {
 
     /**
      * Decode an ASN.1 SEQUENCE by reading the identifier and length octets. The remaining data in the buffer is the SEQUENCE.
-     * 
+     *
      * @param buf
      *            the DER-encoded SEQUENCE
      * @return the length of the SEQUENCE
@@ -234,7 +235,7 @@ public final class Asn1Utils {
 
     /**
      * Encode an ASN.1 BIT STRING.
-     * 
+     *
      * @param value
      *            the value to be encoded
      * @param nbits
@@ -269,12 +270,12 @@ public final class Asn1Utils {
         buf.position(buf.position() - contentLength);
         int headerLength = DerUtils.encodeIdAndLength(DerId.TagClass.UNIVERSAL, DerId.EncodingType.PRIMITIVE,
                 ASN1_BIT_STRING_TAG_NUM, contentLength, buf);
-        return (headerLength + contentLength);
+        return headerLength + contentLength;
     }
 
     /**
      * Encode an ASN.1 GeneralizedTime.
-     * 
+     *
      * @param date
      *            the date value
      * @param buf
@@ -295,15 +296,15 @@ public final class Asn1Utils {
             pos--;
             buf.put(pos, data[i]);
         }
-        buf.position(buf.position()-data.length);
+        buf.position(buf.position() - data.length);
         int headerLength = DerUtils.encodeIdAndLength(DerId.TagClass.UNIVERSAL, DerId.EncodingType.PRIMITIVE,
                 ASN1_GENERALIZED_TIME_TAG_NUM, data.length, buf);
-        return (headerLength + data.length);
+        return headerLength + data.length;
     }
 
     /**
      * Encode an ASN.1 IA5String.
-     * 
+     *
      * @param value
      *            the value to be encoded
      * @param buf
@@ -317,15 +318,15 @@ public final class Asn1Utils {
             pos--;
             buf.put(pos, data[i]);
         }
-        buf.position(buf.position()-data.length);
+        buf.position(buf.position() - data.length);
         int headerLength = DerUtils.encodeIdAndLength(DerId.TagClass.UNIVERSAL, DerId.EncodingType.PRIMITIVE,
                 ASN1_IA5STRING_TAG_NUM, data.length, buf);
-        return (headerLength + data.length);
+        return headerLength + data.length;
     }
 
     /**
      * Encode an ASN.1 INTEGER.
-     * 
+     *
      * @param value
      *            the value to be encoded
      * @param buf
@@ -341,15 +342,15 @@ public final class Asn1Utils {
             value >>>= 8;
             contentLength++;
         } while (value != 0);
-        buf.position(buf.position()-contentLength);
+        buf.position(buf.position() - contentLength);
         int headerLen = DerUtils.encodeIdAndLength(DerId.TagClass.UNIVERSAL, DerId.EncodingType.PRIMITIVE, ASN1_INTEGER_TAG_NUM,
                 contentLength, buf);
-        return (headerLen + contentLength);
+        return headerLen + contentLength;
     }
 
     /**
      * Encode an ASN.1 OCTET STRING.
-     * 
+     *
      * @param octets
      *            the octets
      * @param buf
@@ -365,15 +366,15 @@ public final class Asn1Utils {
             pos--;
             buf.put(pos, (byte) octets[i]);
         }
-        buf.position(buf.position()-octets.length);
+        buf.position(buf.position() - octets.length);
         int headerLength = DerUtils.encodeIdAndLength(DerId.TagClass.UNIVERSAL, DerId.EncodingType.PRIMITIVE,
                 ASN1_OCTET_STRING_TAG_NUM, octets.length, buf);
-        return (headerLength + octets.length);
+        return headerLength + octets.length;
     }
 
     /**
      * Encode an ASN.1 SEQUENCE.
-     * 
+     *
      * @param contentLength
      *            the length of the SEQUENCE
      * @param buf
@@ -383,12 +384,12 @@ public final class Asn1Utils {
     public static int encodeSequence(int contentLength, ByteBuffer buf) {
         int headerLength = DerUtils.encodeIdAndLength(DerId.TagClass.UNIVERSAL, DerId.EncodingType.CONSTRUCTED,
                 ASN1_SEQUENCE_TAG_NUM, contentLength, buf);
-        return (headerLength + contentLength);
+        return headerLength + contentLength;
     }
 
     /**
      * Size of an ASN.1 BIT STRING.
-     * 
+     *
      * @param value
      *            the BIT STRING value
      * @param nbits
@@ -401,7 +402,7 @@ public final class Asn1Utils {
 
     /**
      * Size of an ASN.1 GeneralizedTime.
-     * 
+     *
      * @param date
      *            the date and time
      * @return the size of the encoded data
@@ -412,7 +413,7 @@ public final class Asn1Utils {
 
     /**
      * Size of an ASN.1 IA5String.
-     * 
+     *
      * @param value
      *            the string
      * @return the size of the encoded data
@@ -423,7 +424,7 @@ public final class Asn1Utils {
 
     /**
      * Size of an ASN.1 INTEGER.
-     * 
+     *
      * @param value
      *            the integer value
      * @return the size of the encoded data
@@ -439,7 +440,7 @@ public final class Asn1Utils {
 
     /**
      * Size of an ASN.1 OCTET STRING.
-     * 
+     *
      * @param octets
      *            the octets
      * @return the size of the encoded data
@@ -450,7 +451,7 @@ public final class Asn1Utils {
 
     /**
      * Size of an ASN.1 SEQUENCE.
-     * 
+     *
      * @param length
      *            the length of the SEQUENCE data
      * @return the size of the encoded data

--- a/src/main/java/org/kaazing/gateway/util/aws/AwsUtils.java
+++ b/src/main/java/org/kaazing/gateway/util/aws/AwsUtils.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -55,6 +55,9 @@ import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 public final class AwsUtils {
+    private AwsUtils() {
+    }
+
     private static final Logger LOG = LoggerFactory.getLogger(AwsUtils.class);
 
     private static final String UTF8_CHARSET = "UTF-8";
@@ -63,8 +66,8 @@ public final class AwsUtils {
 
     /**
      * Returns the AccountId of the user who is running the instance.
-     * 
-     * @return String       representing the AccountId or the owner-id 
+     *
+     * @return String       representing the AccountId or the owner-id
      * @throws java.io.IOException  if failed to retrieve the AccountId using the
      *                      Cloud infrastructure
      */
@@ -78,7 +81,7 @@ public final class AwsUtils {
         String idUrl = macUrl + mac + "owner-id";
         String acctId = invokeUrl(idUrl).trim();
 
-        assert(acctId != null);
+        assert  acctId != null;
         return acctId;
     }
 
@@ -110,7 +113,7 @@ public final class AwsUtils {
         // etc. We have to strip that last character to get the
         // correct region.
         String region = zone.substring(0, zone.length() - 1);
-        assert(region != null);
+        assert region != null;
         return region;
     }
 
@@ -321,8 +324,8 @@ public final class AwsUtils {
           connection.setRequestMethod("GET");
 
           // Set 2seconds timeout interval.
-          connection.setConnectTimeout(2*1000);
-          connection.setReadTimeout(2*1000);
+          connection.setConnectTimeout(2 * 1000);
+          connection.setReadTimeout(2 * 1000);
 
           connection.connect();
 
@@ -412,8 +415,11 @@ public final class AwsUtils {
             DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             return db.parse(new ByteArrayInputStream(xmlStr.getBytes()));
         } catch (ParserConfigurationException pcex) {
+            //ignore
         } catch (SAXException saxEx) {
+            //ignore
         } catch (IOException ioex) {
+            //ignore
         }
 
         return null;
@@ -425,9 +431,9 @@ public final class AwsUtils {
                                           String     algorithm)
             throws SignatureException {
 
-        assert(stringToSign != null);
-        assert(awsSecretKey != null);
-        assert(algorithm != null);
+        assert stringToSign != null;
+        assert awsSecretKey != null;
+        assert algorithm != null;
 
         String signature = null;
 
@@ -460,7 +466,7 @@ public final class AwsUtils {
         StringBuilder strBuilder = new StringBuilder();
 
         try {
-            String line = null;
+            String line;
             while ((line = reader.readLine()) != null) {
                 strBuilder.append(line + "\n");
             }
@@ -488,7 +494,7 @@ public final class AwsUtils {
             throws SignatureException {
         String signature = null;
 
-        if ((stringToSign == null) || 
+        if ((stringToSign == null) ||
             (awsSecretKey == null) ||
             (algorithm == null)) {
             return null;
@@ -519,7 +525,7 @@ public final class AwsUtils {
     }
 
     private static String getV1StringToSign(Map<String, String> paramMap) {
-        assert(paramMap != null);
+        assert paramMap != null;
 
         Set<String> sortedKeys = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
         sortedKeys.addAll(paramMap.keySet());
@@ -537,13 +543,13 @@ public final class AwsUtils {
     }
 
     private static String getV2CanonicalizedQueryString(Map<String, String> params) {
-        assert((params != null) && !params.isEmpty());
+        assert params != null && !params.isEmpty();
 
         SortedMap<String, String> sortedMap = new TreeMap<String, String>(params);
 
         // Remove "Signature" parameter, if added.
         sortedMap.remove("Signature");
-        
+
         StringBuffer buffer = new StringBuffer();
         Iterator<Map.Entry<String, String>> iter = sortedMap.entrySet().iterator();
 
@@ -556,16 +562,16 @@ public final class AwsUtils {
                 buffer.append("&");
             }
         }
-     
+
         return buffer.toString();
     }
 
     // Based on RFC 3986 and AWS doc, further encode certain characters.
     private static String rfc3986Conformance(String s) {
-        assert(s != null);
+        assert s != null;
 
         String out = null;
-        
+
         if (s == null) {
             return null;
         }

--- a/src/main/java/org/kaazing/gateway/util/aws/Codec.java
+++ b/src/main/java/org/kaazing/gateway/util/aws/Codec.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,16 +24,19 @@ package org.kaazing.gateway.util.aws;
 import java.nio.ByteBuffer;
 
 public class Codec {
+    protected Codec() {
+    }
 
     // HEX
-    
-    private static final byte[] TO_HEX = new byte[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
-    
+
+    private static final byte[] TO_HEX =
+            new byte[] {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+
     public static final String encodeHexString(byte[] data) {
         byte[] out = encodeHex(data);
         return new String(out);
     }
-    
+
     public static final byte[] encodeHex(byte[] data) {
         int len = data.length;
         byte[] out = new byte[len << 1];
@@ -47,9 +50,9 @@ public class Codec {
         }
         return out;
     }
-    
+
     // Base64
-    
+
     private static final byte[] TO_BASE64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".getBytes();
     private static final byte BASE64_PADDING_BYTE = (byte) '=';
 
@@ -57,7 +60,7 @@ public class Codec {
         if (data == null) {
             return null;
         }
-        
+
         return decodeBase64(data).asCharBuffer().toString();
     }
 
@@ -65,7 +68,7 @@ public class Codec {
         if (data == null) {
             return null;
         }
-        
+
         return encodeBase64String(ByteBuffer.wrap(data));
     }
 
@@ -79,7 +82,7 @@ public class Codec {
                 remaining--;
 
                 buf.put(TO_BASE64[(byte0 >> 2) & 0x3f]);
-                buf.put(TO_BASE64[((byte0 << 4) & 0x30)]);
+                buf.put(TO_BASE64[(byte0 << 4) & 0x30]);
                 buf.put(BASE64_PADDING_BYTE);
                 buf.put(BASE64_PADDING_BYTE);
                 break;
@@ -148,10 +151,10 @@ public class Codec {
             }
         }
         buf.flip();
-        return (buf.slice());
+        return buf.slice();
     }
 
-    private static final byte mapped(int index) {
+    private static byte mapped(int index) {
         switch (index) {
         case BASE64_PADDING_BYTE:
         case 'A':
@@ -286,5 +289,5 @@ public class Codec {
             throw new IllegalArgumentException("Invalid base64 string");
         }
     }
-    
+
 }

--- a/src/main/java/org/kaazing/gateway/util/codec/PassThroughDecoder.java
+++ b/src/main/java/org/kaazing/gateway/util/codec/PassThroughDecoder.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/main/java/org/kaazing/gateway/util/codec/PassThroughEncoder.java
+++ b/src/main/java/org/kaazing/gateway/util/codec/PassThroughEncoder.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -30,15 +30,15 @@ import org.apache.mina.filter.codec.ProtocolEncoderOutput;
  * This is a simple encoder used by different protocol extensions in KEG
  * where the stream from the server is passed to the client unchanged.
  *
- * @author sidda
  *
  */
 public class PassThroughEncoder extends ProtocolEncoderAdapter {
 
     public static PassThroughEncoder PASS_THROUGH_ENCODER = new PassThroughEncoder();
 
-    /* (non-Javadoc)
-     * @see org.apache.mina.filter.codec.ProtocolEncoder#encode(org.apache.mina.core.session.IoSession, java.lang.Object, org.apache.mina.filter.codec.ProtocolEncoderOutput)
+    /*
+     * @see org.apache.mina.filter.codec.ProtocolEncoder#
+     * encode(org.apache.mina.core.session.IoSession, java.lang.Object, org.apache.mina.filter.codec.ProtocolEncoderOutput)
      */
     @Override
     public void encode(IoSession session, Object message,

--- a/src/main/java/org/kaazing/gateway/util/der/DerId.java
+++ b/src/main/java/org/kaazing/gateway/util/der/DerId.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -50,7 +50,7 @@ public class DerId {
 
     /**
      * Gets the tag class.
-     * 
+     *
      * @return the tag class
      */
     public TagClass getTagClass() {
@@ -59,7 +59,7 @@ public class DerId {
 
     /**
      * Gets the encoding type.
-     * 
+     *
      * @return the encoding type
      */
     public EncodingType getEncodingType() {
@@ -68,7 +68,7 @@ public class DerId {
 
     /**
      * Gets the tag number.
-     * 
+     *
      * @return the tag number
      */
     public int getTagNumber() {
@@ -77,12 +77,14 @@ public class DerId {
 
     @Override
     public String toString() {
-        return "DerId [tagClass=" + getTagClass() + ", encodingType=" + getEncodingType() + ", tagNumber=" + getTagNumber() + "]";
+        return "DerId [tagClass=" + getTagClass() +
+                ", encodingType=" + getEncodingType() +
+                ", tagNumber=" + getTagNumber() + "]";
     }
 
     /**
      * Decodes identifier octets from a DER-encoded message.
-     * 
+     *
      * @param buf
      *            the buffer containing the DER-encoded message
      * @return the DER identifier
@@ -104,7 +106,7 @@ public class DerId {
 
         // Bits 5 through 1 represent the tag number if tag number is less than 30.
         // Bits 5 through 1 are set to 1 if the tag number is greater than 30.
-        int tagNum = (first & 0x1f);
+        int tagNum = first & 0x1f;
         if (tagNum == 0x1F) {
             // Tag number greater than 30
             if (buf.remaining() == 0) {
@@ -126,7 +128,7 @@ public class DerId {
 
     /**
      * Tests whether this DER identifier matches the specified tag class, encoding type and tag number.
-     * 
+     *
      * @param tagClass
      *            the tag class to match against
      * @param encodingType
@@ -136,12 +138,13 @@ public class DerId {
      * @return whether there's a match
      */
     public boolean matches(TagClass tagClass, EncodingType encodingType, int tagNumber) {
-        return (this.tagClass == tagClass && this.encodingType == encodingType && this.tagNumber == tagNumber);
+        return this.tagClass == tagClass && this.encodingType == encodingType && this.tagNumber == tagNumber;
     }
 
     /**
-     * Tests whether this DER identifier matches the specified tag class and tag number. (Encoding type could be either one of the encoding types).
-     * 
+     * Tests whether this DER identifier matches the specified tag class and tag number.
+     * (Encoding type could be either one of the encoding types).
+     *
      * @param tagClass
      *            the tag class to match against
      * @param tagNumber
@@ -149,6 +152,6 @@ public class DerId {
      * @return whether there's a match
      */
     public boolean matches(TagClass tagClass, int tagNumber) {
-        return (this.tagClass == tagClass && this.tagNumber == tagNumber);
+        return this.tagClass == tagClass && this.tagNumber == tagNumber;
     }
 }

--- a/src/main/java/org/kaazing/gateway/util/der/DerUtils.java
+++ b/src/main/java/org/kaazing/gateway/util/der/DerUtils.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -32,7 +32,7 @@ public final class DerUtils {
 
     /**
      * Decode octets and extract the length information from a DER-encoded message.
-     * 
+     *
      * @param buf
      *            the DER-encoded data buffer with position immediately after the DER-identifier octets
      * @return the length of the DER-encoded contents
@@ -47,11 +47,11 @@ public final class DerUtils {
         byte first = buf.get();
         if (first >> 7 == 0) {
             // Bit 8 is zero: Short form
-            len = (first & 0x7f);
+            len = first & 0x7f;
         } else {
             // Bit 8 is one: Long form
             // Bit 7-1 represents number of subsequent octets
-            int numOctets = (first & 0x7f);
+            int numOctets = first & 0x7f;
             if (buf.remaining() < numOctets) {
                 throw new IllegalArgumentException("Insufficient data to decode long-form DER length");
             }
@@ -67,7 +67,7 @@ public final class DerUtils {
 
     /**
      * Decodes ID and length octets from a DER-encoded message.
-     * 
+     *
      * @param buf
      *            the buffer with the DER-encoded message
      * @return the ID
@@ -80,7 +80,7 @@ public final class DerUtils {
 
     /**
      * DER-encode content into a provided buffer.
-     * 
+     *
      * @param tagClass
      *            the tag class
      * @param encodingType
@@ -172,12 +172,12 @@ public final class DerUtils {
 
         // skip (origPos - pos) bytes
         buf.position(pos);
-        return (origPos - pos);
+        return origPos - pos;
     }
 
     /**
      * Computes the DER-encoded size of content with a specified tag number.
-     * 
+     *
      * @param tagNumber
      *            the DER tag number in the identifier
      * @param contentLength
@@ -195,14 +195,14 @@ public final class DerUtils {
         if (tagNumber <= 30) {
             len++; // single octet
         } else {
-            len += (1 + (int) Math.ceil((1 + Integer.numberOfTrailingZeros(Integer.highestOneBit(tagNumber))) / 7.0d));
+            len = len + 1 + (int) Math.ceil((1 + Integer.numberOfTrailingZeros(Integer.highestOneBit(tagNumber))) / 7.0d);
         }
 
         // Length octets (TODO: indefinite form)
         if (contentLength <= 0x7f) {
             len++; // definite form, single octet
         } else {
-            len += (1 + (int) Math.ceil((1 + Integer.numberOfTrailingZeros(Integer.highestOneBit(contentLength))) / 8.0d));
+            len = len + 1 + (int) Math.ceil((1 + Integer.numberOfTrailingZeros(Integer.highestOneBit(contentLength))) / 8.0d);
         }
 
         // Content octets

--- a/src/main/java/org/kaazing/gateway/util/file/FileUtils.java
+++ b/src/main/java/org/kaazing/gateway/util/file/FileUtils.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -27,7 +27,10 @@ import java.io.File;
  * Utility routines for file management.
  */
 public class FileUtils {
-    
+
+    protected FileUtils() {
+    }
+
     /**
      * Given a File object, return the extension (portion after the final '.'), if any.
      * If no extension, returns null.  If the file parameter is null, returns null.
@@ -37,9 +40,9 @@ public class FileUtils {
         if (file == null) {
             return null;
         }
-        
+
         String fileName = file.getName();
         int dotPos = fileName.lastIndexOf('.');
-        return (dotPos == -1 ? null : fileName.substring(dotPos + 1));
+        return dotPos == -1 ? null : fileName.substring(dotPos + 1);
     }
 }

--- a/src/main/java/org/kaazing/gateway/util/http/DefaultUtilityHttpClient.java
+++ b/src/main/java/org/kaazing/gateway/util/http/DefaultUtilityHttpClient.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/main/java/org/kaazing/gateway/util/http/UtilityHttpClient.java
+++ b/src/main/java/org/kaazing/gateway/util/http/UtilityHttpClient.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,12 +22,12 @@
 package org.kaazing.gateway.util.http;
 
 public interface UtilityHttpClient {
-	/**
-	 * Returns the body of a get request iff the result is a 200 OK
-	 * 
-	 * @param url
-	 * @return
-	 * @throws Exception
-	 */
-	public String performGetRequest(String url) throws Exception;
+    /**
+     * Returns the body of a get request iff the result is a 200 OK
+     *
+     * @param url
+     * @return
+     * @throws Exception
+     */
+     String performGetRequest(String url) throws Exception;
 }

--- a/src/main/java/org/kaazing/gateway/util/parse/ConfigParameter.java
+++ b/src/main/java/org/kaazing/gateway/util/parse/ConfigParameter.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -44,7 +44,7 @@ public abstract class ConfigParameter {
 
     /**
      * regex to capture parameter definitions amongst free text as per
-     * {@link #resolveAndReplace(char[], int, int, Properties, List)}
+     * {@link # resolveAndReplace(char[], int, int, Properties, List)}
      */
     private static final Pattern PARAM_REGEX = Pattern.compile("([\\$]?)([\\$]+\\{)([^\\{\\}]*)(\\})");
 
@@ -62,7 +62,8 @@ public abstract class ConfigParameter {
     };
 
     private enum ParameterResolutionStrategy {
-        PARAMETER_DEFINITION_DEFAULT, PARAMETER_PROPERTIES_FILE, SYSTEM_PROPERTIES, ENVIRONMENT_VARIABLES, ESCAPED_PARAMETER_DEFINITION, UNRESOLVED_PARAMETER_DEFINITION, CLOUD_RESOLUTION_STRATEGY
+        PARAMETER_DEFINITION_DEFAULT, PARAMETER_PROPERTIES_FILE, SYSTEM_PROPERTIES, ENVIRONMENT_VARIABLES,
+        ESCAPED_PARAMETER_DEFINITION, UNRESOLVED_PARAMETER_DEFINITION, CLOUD_RESOLUTION_STRATEGY
     };
 
     /**
@@ -90,8 +91,8 @@ public abstract class ConfigParameter {
      * @param offset the offset into <code>chars</code>
      * @param length the length of <code>chars</code> to consider
      * @param parameterValuePairs parameter name value pairs used for resolution
-     * @param configuration Properties used to override parameterValuePairs.  The latter is specified in the config file, the former
-     *        is passed to the Gateway either on the command line or when configuring a Gateway.
+     * @param configuration Properties used to override parameterValuePairs.  The latter is specified in the config file,
+     *                      the former is passed to the Gateway either on the command line or when configuring a Gateway.
      * @param errors list of <code>String</code> errors
      * @return the new string, with all parameters replaced by their resolved value
      */
@@ -113,7 +114,7 @@ public abstract class ConfigParameter {
             lastMatchCharIndex = matcher.end(ParameterRegex.CLOSE.index);
 
             // match escape sequence
-            if ( matcher.start(ParameterRegex.ESCAPE.index) != matcher.end(ParameterRegex.ESCAPE.index) ) {
+            if (matcher.start(ParameterRegex.ESCAPE.index) != matcher.end(ParameterRegex.ESCAPE.index)) {
                 // we have an escaped out match, drop leading escape tokens and pass the match through unchanged
                 value = new String(chars, offset + matcher.start(ParameterRegex.OPEN.index),
                         matcher.end(ParameterRegex.CLOSE.index) - matcher.start(ParameterRegex.OPEN.index));
@@ -122,51 +123,57 @@ public abstract class ConfigParameter {
             // match parameter definition
             else {
                 // attempt to resolve value from hierarchy of value stores
-                if ( !"".equals(name) )
-                    if ( (value = configuration.getProperty(name)) != null && !"".equals(value) )
+                if (!"".equals(name)) {
+                    if ((value = configuration.getProperty(name)) != null && !"".equals(value)) {
                         strategy = ParameterResolutionStrategy.SYSTEM_PROPERTIES;
-                    else if ( (value = parameterValuePairs.get(name)) != null && !"".equals(value) )
+                    }
+                    else if ((value = parameterValuePairs.get(name)) != null && !"".equals(value)) {
                         strategy = ParameterResolutionStrategy.PARAMETER_DEFINITION_DEFAULT;
+                    }
+                }
             }
 
-			// resolve cloud.host
-			if (value == null && "cloud.host".equals(matcher.group(3))) {
-				LOGGER.info("${cloud.host} found in config, attempting resolution by searching cloud provider");
-				strategy = ParameterResolutionStrategy.CLOUD_RESOLUTION_STRATEGY;
-				value = resolveCloudHost(new DefaultUtilityHttpClient());
-				// value may be returned as null but that is good so it is caught as can't 
-				// determine value
-				if (value == null){
-					LOGGER.warn("${cloud.host} detected in config but could not determine cloud enviroment and find valid replacement for it");
-				}
-			}
+            // resolve cloud.host
+            if (value == null && "cloud.host".equals(matcher.group(3))) {
+                LOGGER.info("${cloud.host} found in config, attempting resolution by searching cloud provider");
+                strategy = ParameterResolutionStrategy.CLOUD_RESOLUTION_STRATEGY;
+                value = resolveCloudHost(new DefaultUtilityHttpClient());
+                // value may be returned as null but that is good so it is caught as can't
+                // determine value
+                if (value == null) {
+                    LOGGER.warn("${cloud.host} detected in config but could not " +
+                            "determine cloud enviroment and find valid replacement for it");
+                }
+            }
 
-			// resolve cloud.instanceId
-			if (value == null && "cloud.instanceId".equals(matcher.group(3))) {
-				LOGGER.info("${cloud.instanceId} found in config, attempting resolution by searching cloud provider");
-				strategy = ParameterResolutionStrategy.CLOUD_RESOLUTION_STRATEGY;
-				value = resolveCloudInstanceId(new DefaultUtilityHttpClient());
-				// value may be returned as null but that is good so it is caught as can't 
-				// determine value
-				if (value == null){
-					LOGGER.warn("${cloud.instanceId} detected in config but could not determine cloud enviroment and find valid replacement for it");
-				}
-			}
+            // resolve cloud.instanceId
+            if (value == null && "cloud.instanceId".equals(matcher.group(3))) {
+                LOGGER.info("${cloud.instanceId} found in config, attempting resolution by searching cloud provider");
+                strategy = ParameterResolutionStrategy.CLOUD_RESOLUTION_STRATEGY;
+                value = resolveCloudInstanceId(new DefaultUtilityHttpClient());
+                // value may be returned as null but that is good so it is caught as can't
+                // determine value
+                if (value == null) {
+                    LOGGER.warn("${cloud.instanceId} detected in config but could not " +
+                            "determine cloud enviroment and find valid replacement for it");
+                }
+            }
 
-			// if not resolved, add error and pass match through unchanged
-			if (value == null || "".equals(value)) {
-				value = matcher.group();
-				strategy = ParameterResolutionStrategy.UNRESOLVED_PARAMETER_DEFINITION;
-				errors.add("Could not determine non-null value for parameter definition "
-						+ matcher.group());
-			}
+            // if not resolved, add error and pass match through unchanged
+            if (value == null || "".equals(value)) {
+                value = matcher.group();
+                strategy = ParameterResolutionStrategy.UNRESOLVED_PARAMETER_DEFINITION;
+                errors.add("Could not determine non-null value for parameter definition "
+                        + matcher.group());
+            }
 
             // add resolved value
             string.append(value);
 
-            if ( LOGGER.isInfoEnabled() )
+            if (LOGGER.isInfoEnabled()) {
                 LOGGER.info("Detected configuration parameter [" + matcher.group() + "], replaced with [" + value
                         + "], as a result of resolution strategy [" + strategy + "]");
+            }
         }
 
         // we have a match/non-match, process suffix/entire buffer
@@ -174,71 +181,71 @@ public abstract class ConfigParameter {
 
         return string.toString();
     }
-    
-    public static String cachedCloudHost = null;
-    public static String cachedCloudInstanceId = null;
 
-	// public with UtilityHttpClient is for testing
-	public static String resolveCloudHost(UtilityHttpClient httpClient) {
-		// cached so we only attempt it once
-		if(cachedCloudHost == null){
-			String value = null;
-			// AWS
-			LOGGER.debug("Attempting to get AWS host information");
-	
-			try {
-				String response = httpClient
-						.performGetRequest("http://169.254.169.254/2014-02-25/meta-data/public-hostname");
-				// confirm it has a aws hostname
-				if (response != null && response.contains("amazonaws.com")) {
-					value = response;
-					LOGGER.debug(format("Found AWS hostname: %s", value));
-				} else if (response != null && "".equals(response)) {
-					// sometimes aws does not get a hostname, so we fallback to use
-					// the public ip
-					response = httpClient
-							.performGetRequest("http://169.254.169.254/2014-02-25/meta-data/public-ipv4");
-					if (response != null) {
-						value = response;
-						LOGGER.debug(format(
-								"Couldn't find AWS hostname, but did find AWS public ip: %s",
-								value));
-					}
-				}
-	
-			} catch (Exception e) {
-				// NOOP try next supported cloud provider if it exists
-				LOGGER.debug(format("failed to get value due to exception with message: %s ", e.getMessage()));
-			}
-			// TODO: Add more as we support cloud platforms
-			cachedCloudHost = value;
-		}
-		return cachedCloudHost;
-	}
+    public static String cachedCloudHost;
+    public static String cachedCloudInstanceId;
 
-	// public with UtilityHttpClient is for testing
-	public static String resolveCloudInstanceId(UtilityHttpClient httpClient) {
-		// cached so we only attempt it once
-		if (cachedCloudInstanceId == null) {
-			String value = null;
-			// AWS
-			LOGGER.debug("Attempting to get AWS instanceId information");
+    // public with UtilityHttpClient is for testing
+    public static String resolveCloudHost(UtilityHttpClient httpClient) {
+        // cached so we only attempt it once
+        if (cachedCloudHost == null) {
+            String value = null;
+            // AWS
+            LOGGER.debug("Attempting to get AWS host information");
 
-			try {
-				String response = httpClient
-						.performGetRequest("http://169.254.169.254/2014-02-25/meta-data/instance-id");
-				// confirm it has a aws hostname
-				if (response != null) {
-					value = response;
-					LOGGER.debug(format("Found AWS instanceId: %s", value));
-				}
-			} catch (Exception e) {
-				// NOOP try next supported cloud provider if it exists
-			}
-			// TODO: Add more as we support cloud platforms
-			cachedCloudInstanceId = value;
-		}
-		return cachedCloudInstanceId;
-	}
+            try {
+                String response = httpClient
+                        .performGetRequest("http://169.254.169.254/2014-02-25/meta-data/public-hostname");
+                // confirm it has a aws hostname
+                if (response != null && response.contains("amazonaws.com")) {
+                    value = response;
+                    LOGGER.debug(format("Found AWS hostname: %s", value));
+                } else if (response != null && "".equals(response)) {
+                    // sometimes aws does not get a hostname, so we fallback to use
+                    // the public ip
+                    response = httpClient
+                            .performGetRequest("http://169.254.169.254/2014-02-25/meta-data/public-ipv4");
+                    if (response != null) {
+                        value = response;
+                        LOGGER.debug(format(
+                                "Couldn't find AWS hostname, but did find AWS public ip: %s",
+                                value));
+                    }
+                }
+
+            } catch (Exception e) {
+                // NOOP try next supported cloud provider if it exists
+                LOGGER.debug(format("failed to get value due to exception with message: %s ", e.getMessage()));
+            }
+            // TODO: Add more as we support cloud platforms
+            cachedCloudHost = value;
+        }
+        return cachedCloudHost;
+    }
+
+    // public with UtilityHttpClient is for testing
+    public static String resolveCloudInstanceId(UtilityHttpClient httpClient) {
+        // cached so we only attempt it once
+        if (cachedCloudInstanceId == null) {
+            String value = null;
+            // AWS
+            LOGGER.debug("Attempting to get AWS instanceId information");
+
+            try {
+                String response = httpClient
+                        .performGetRequest("http://169.254.169.254/2014-02-25/meta-data/instance-id");
+                // confirm it has a aws hostname
+                if (response != null) {
+                    value = response;
+                    LOGGER.debug(format("Found AWS instanceId: %s", value));
+                }
+            } catch (Exception e) {
+                // NOOP try next supported cloud provider if it exists
+            }
+            // TODO: Add more as we support cloud platforms
+            cachedCloudInstanceId = value;
+        }
+        return cachedCloudInstanceId;
+    }
 
 }

--- a/src/main/java/org/kaazing/gateway/util/scheduler/SchedulerProvider.java
+++ b/src/main/java/org/kaazing/gateway/util/scheduler/SchedulerProvider.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -48,14 +48,18 @@ public class SchedulerProvider {
 
 
     /*
-     * @param owner               - Object which will be using the scheduler (and shutting it down when the object is disposed)
-     * @param purpose             - short description of the purpose of the scheduler, will be set as the thread name if a dedicated thread is used
-     * @param needDedicatedThread - set this to true to guarantee the scheduler will have its own dedicated thread. This is appropriate if the tasks
-     *                              that will be scheduled may take significant time, e.g. sending periodic keep alive messages to all sessions
+     * @param owner    Object which will be using the scheduler (and shutting it down when the object is disposed)
+     *
+     * @param purpose  short description of the purpose of the scheduler, will be set as the thread name
+     *                 if a dedicated thread is used
+     *
+     * @param needDedicatedThread set this to true to guarantee the scheduler will have its own dedicated thread.
+     *                            This is appropriate if the tasks that will be scheduled may take significant time,
+     *                            e.g. sending periodic keep alive messages to all sessions
      * @return
      */
     public synchronized ScheduledExecutorService getScheduler(final String purpose, boolean needDedicatedThread) {
-        if ( needDedicatedThread ) {
+        if (needDedicatedThread) {
             return new ManagedScheduledExecutorService(1, purpose, false);
         }
         else {
@@ -63,17 +67,17 @@ public class SchedulerProvider {
             return sharedScheduler;
         }
     }
-    
+
     public synchronized void shutdownNow() {
-        for ( ManagedScheduledExecutorService scheduler : schedulers ) {
+        for (ManagedScheduledExecutorService scheduler : schedulers) {
             scheduler.shutdownImmediate();
         }
     }
- 
+
     /**
      * This class represents a scheduler which may be shared. If it is, attempts to shut it down using the standard
      * ScheduledExecutorService methods shutdown and shutdownNow will be noops.
-     * 
+     *
      */
     private class ManagedScheduledExecutorService extends ScheduledThreadPoolExecutor {
         private boolean shared;
@@ -85,7 +89,7 @@ public class SchedulerProvider {
 
                 @Override
                 public Thread newThread(Runnable r) {
-                    return new Thread(r, namePrefix+poolNumber.getAndIncrement());
+                    return new Thread(r, namePrefix + poolNumber.getAndIncrement());
                 }
             });
             this.shared = shared;
@@ -94,14 +98,14 @@ public class SchedulerProvider {
 
         @Override
         public void shutdown() {
-            if ( !shared ) {
+            if (!shared) {
                 super.shutdown();
             }
         }
 
         @Override
         public List<Runnable> shutdownNow() {
-            if ( !shared ) {
+            if (!shared) {
                 return super.shutdownNow();
             }
             else {
@@ -113,5 +117,5 @@ public class SchedulerProvider {
             super.shutdownNow();
         }
     }
-    
+
 }

--- a/src/main/java/org/kaazing/gateway/util/ssl/SslCipherSuites.java
+++ b/src/main/java/org/kaazing/gateway/util/ssl/SslCipherSuites.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -30,6 +30,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class SslCipherSuites {
+
+    protected SslCipherSuites() {
+    }
 
     private static enum CipherStrength {
         HIGH("HIGH"),
@@ -243,7 +246,7 @@ public class SslCipherSuites {
                        getStrengthBits().hashCode();
             return code;
         }
- 
+
         @Override
         public int compareTo(Object o) {
             if (o == null) {
@@ -254,7 +257,7 @@ public class SslCipherSuites {
 
             // To sort the ciphers in DESCENDING order of bits, we need to
             // invert the normal comparison
-            return (getStrengthBits().compareTo(c.getStrengthBits()) * -1);
+            return getStrengthBits().compareTo(c.getStrengthBits()) * -1;
         }
 
         @Override
@@ -275,7 +278,7 @@ public class SslCipherSuites {
         public OtherSslCipher(String name) {
             super(name, null, 0, null, null, null, null, null, null, false);
         }
-     
+
         @Override
         public int hashCode() {
             return getName().hashCode();
@@ -288,10 +291,10 @@ public class SslCipherSuites {
     }
 
     private static enum CipherOp {
-      ADD,		// default
-      KILL,		// '!' prefix
-      RIGHT_SHIFT,	// '+' prefix
-      REMOVE;		// '-' prefix
+      ADD,        // default
+      KILL,        // '!' prefix
+      RIGHT_SHIFT,    // '+' prefix
+      REMOVE;        // '-' prefix
     }
 
     // These mappings are based on the groupings used by OpenSSL; see
@@ -300,34 +303,34 @@ public class SslCipherSuites {
     //   openssl/ssl/s3_lib.c.
     //   openssl/ssl/ssl_locl.h
 
-    private static final ConcurrentMap<String, List<SslCipher>> CIPHER_STRENGTHS = new ConcurrentHashMap<String, List<SslCipher>>();
-    private static boolean filledStrengths = false;
+    private static final ConcurrentMap<String, List<SslCipher>> CIPHER_STRENGTHS = new ConcurrentHashMap<>();
+    private static boolean filledStrengths;
 
-    private static final ConcurrentMap<String, List<SslCipher>> CIPHER_KEY_EXCHANGES = new ConcurrentHashMap<String, List<SslCipher>>();
-    private static boolean filledKeyExchanges = false;
+    private static final ConcurrentMap<String, List<SslCipher>> CIPHER_KEY_EXCHANGES = new ConcurrentHashMap<>();
+    private static boolean filledKeyExchanges;
 
-    private static final ConcurrentMap<String, List<SslCipher>> CIPHER_AUTHNS = new ConcurrentHashMap<String, List<SslCipher>>();
-    private static boolean filledAuths = false;
+    private static final ConcurrentMap<String, List<SslCipher>> CIPHER_AUTHNS = new ConcurrentHashMap<>();
+    private static boolean filledAuths;
 
-    private static final ConcurrentMap<String, List<SslCipher>> CIPHER_ENCRYPTS = new ConcurrentHashMap<String, List<SslCipher>>();
-    private static boolean filledEncrypts = false;
+    private static final ConcurrentMap<String, List<SslCipher>> CIPHER_ENCRYPTS = new ConcurrentHashMap<>();
+    private static boolean filledEncrypts;
 
-    private static final ConcurrentMap<String, List<SslCipher>> CIPHER_MACS = new ConcurrentHashMap<String, List<SslCipher>>();
-    private static boolean filledMACs = false;
+    private static final ConcurrentMap<String, List<SslCipher>> CIPHER_MACS = new ConcurrentHashMap<>();
+    private static boolean filledMACs;
 
-    private static final ConcurrentMap<String, List<SslCipher>> CIPHER_PROTOCOLS = new ConcurrentHashMap<String, List<SslCipher>>();
-    private static boolean filledProtocols = false;
+    private static final ConcurrentMap<String, List<SslCipher>> CIPHER_PROTOCOLS = new ConcurrentHashMap<>();
+    private static boolean filledProtocols;
 
-    private static final List<SslCipher> CIPHER_FIPS = new LinkedList<SslCipher>();
-    private static boolean filledFIPS = false;
+    private static final List<SslCipher> CIPHER_FIPS = new LinkedList<>();
+    private static boolean filledFIPS;
 
     // Map of the ciphersuite name (as appearing in IETF specs) to
     // various details about that ciphersuite
-    private static boolean filledCiphers = false;
-    private static final ConcurrentMap<String, SslCipher> CIPHERS = new ConcurrentHashMap<String, SslCipher>();
+    private static boolean filledCiphers;
+    private static final ConcurrentMap<String, SslCipher> CIPHERS = new ConcurrentHashMap<>();
 
     // Map of the ciphersuite name (as defined as a nickname in OpenSSL)
-    private static final ConcurrentMap<String, SslCipher> CIPHER_NICKNAMES = new ConcurrentHashMap<String, SslCipher>();
+    private static final ConcurrentMap<String, SslCipher> CIPHER_NICKNAMES = new ConcurrentHashMap<>();
 
     private static void initStrengthGroups(ConcurrentMap<String, List<SslCipher>> groups) {
         // HIGH
@@ -683,7 +686,8 @@ public class SslCipherSuites {
 
     // These names are those documented in:
     //   http://docs.oracle.com/javase/6/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider
-    private static void initJava6SunCipherSuites(ConcurrentMap<String, SslCipher> ciphers, ConcurrentMap<String, SslCipher> ciphersByNickname) {
+    private static void initJava6SunCipherSuites(ConcurrentMap<String, SslCipher> ciphers,
+                                                 ConcurrentMap<String, SslCipher> ciphersByNickname) {
         SslCipher cipher = null;
 
         // SSL_RSA_WITH_RC4_128_MD5
@@ -1505,8 +1509,9 @@ public class SslCipherSuites {
 
     // These names are those documented in:
     //   http://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider
-    private static void initJava7SunCipherSuites(ConcurrentMap<String, SslCipher> ciphers, ConcurrentMap<String, SslCipher> ciphersByNickname) {
-        SslCipher cipher = null;
+    private static void initJava7SunCipherSuites(ConcurrentMap<String, SslCipher> ciphers,
+                                                 ConcurrentMap<String, SslCipher> ciphersByNickname) {
+        SslCipher cipher;
 
         // TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
         cipher = new SslCipher("TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
@@ -1772,22 +1777,22 @@ public class SslCipherSuites {
         if (ciphers != null) {
             return ciphers;
         }
- 
+
         ciphers = CIPHER_KEY_EXCHANGES.get(token);
         if (ciphers != null) {
             return ciphers;
         }
- 
+
         ciphers = CIPHER_AUTHNS.get(token);
         if (ciphers != null) {
             return ciphers;
         }
- 
+
         ciphers = CIPHER_ENCRYPTS.get(token);
         if (ciphers != null) {
             return ciphers;
         }
- 
+
         ciphers = CIPHER_MACS.get(token);
         if (ciphers != null) {
             return ciphers;
@@ -1913,7 +1918,7 @@ public class SslCipherSuites {
                         }
                     }
 
-                    int idx = resolvedCiphers.size()-1;
+                    int idx = resolvedCiphers.size() - 1;
                     if (idx < 0) {
                         idx = 0;
                     }
@@ -1976,7 +1981,7 @@ public class SslCipherSuites {
             } else if (token.equals("DSS")) {
                 iter.remove();
                 iter.add(CipherAuthentication.DSS.getTokenName());
-    
+
             } else if (token.equals("ECDSA")) {
                 iter.remove();
                 iter.add(CipherAuthentication.ECDSA.getTokenName());
@@ -2113,10 +2118,10 @@ public class SslCipherSuites {
     // String array.
 
     public static String[] resolveCSV(String csv) {
-        List<String> resolved = null;
+        List<String> resolved;
 
         if (csv != null &&
-            csv.equals("") == false) {
+                ! csv.equals("")) {
             String[] elts = csv.split(",");
             List<String> tokens = new ArrayList<String>(elts.length);
             for (String elt : elts) {

--- a/src/main/java/org/kaazing/gateway/util/ws/WebSocketWireProtocol.java
+++ b/src/main/java/org/kaazing/gateway/util/ws/WebSocketWireProtocol.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,7 +25,8 @@ package org.kaazing.gateway.util.ws;
  * Models the wire protocol versions of the IETF Web Socket Specification,
  * and associate specification version(s) with each known wire protocol.
  * <p/>
- * For example, see <a href="http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-17">the latest websocket specification</a>
+ * For example,
+ * see <a href="http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-17">the latest websocket specification</a>
  * as of writing with specification version 17 and wire protocol version 13.
  * <p/>
  * Note: arbitrary specification version numbers are assigned to Hixie-75 and Hixie-76 versions of the protocol.

--- a/src/test/java/org/kaazing/gateway/util/EncodingTest.java
+++ b/src/test/java/org/kaazing/gateway/util/EncodingTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -46,55 +46,55 @@ public class EncodingTest {
         	return byteBuffer.asReadOnlyBuffer();
         }
     }
-    
+
     private void encodeUtf8(boolean withArray) {
         byte[] decodedWithOffset4 = new byte[] {0, 0, 0, 0, 0, 1, 2, 4, 8, 16, 32, 64, -128, -64, -1};
         ByteBuffer in = asReadOnlyIfNeeded(ByteBuffer.wrap(decodedWithOffset4, 4, decodedWithOffset4.length - 4), withArray);
-        
+
         ByteBuffer out = Encoding.UTF8.encode(in);
-        
+
         ByteBuffer expected = ByteBuffer.wrap(new byte[] {0, 1, 2, 4, 8, 16, 32, 64, -62, -128, -61, -128, -61, -65});
         assertEquals(expected, out);
     }
-    
+
     @Test
     public void encodeUtf8() {
     	encodeUtf8(true);
     }
-    
+
     @Test
     public void encodeUtf8NoArray() {
     	encodeUtf8(false);
     }
-    
+
     private void decodeUtf8(boolean withArray) {
         // 00 01 02 04 08 10 20 40 C2 80 C3 80 C3 BF
         ByteBuffer in = asReadOnlyIfNeeded(ByteBuffer.wrap(new byte[] {0, 1, 2, 4, 8, 16, 32, 64, -62, -128, -61, -128, -61, -65}), withArray);
 
         // 00 01 02 04 08 10 20 40 80 C0 FF
         ByteBuffer expected = ByteBuffer.wrap(new byte[] {0, 1, 2, 4, 8, 16, 32, 64, -128, -64, -1});
-        
+
         ByteBuffer out = Encoding.UTF8.decode(in);
-        
+
         assertEquals(expected, out);
     }
-    
+
     @Test
     public void decodeUtf8() {
     	decodeUtf8(true);
     }
-    
+
     @Test
     public void decodeUtf8NoArray() {
     	decodeUtf8(false);
     }
-    
+
     private void decodeUtf8Offset(boolean withArray) {
         byte[] data = new byte[] {8, -61, -65, 0, 1, 2, 4, 8, 16, 32, 64, -62, -128, -61, -128, -61, -65};
-        ByteBuffer in = asReadOnlyIfNeeded(ByteBuffer.wrap(data, /*offset*/ 3, data.length-3), withArray);
-        
+        ByteBuffer in = asReadOnlyIfNeeded(ByteBuffer.wrap(data, /*offset*/ 3, data.length - 3), withArray);
+
         ByteBuffer out = Encoding.UTF8.decode(in);
-        
+
         ByteBuffer expected = ByteBuffer.wrap(new byte[] {0, 1, 2, 4, 8, 16, 32, 64, -128, -64, -1});
         assertEquals(expected, out);
     }
@@ -103,18 +103,18 @@ public class EncodingTest {
     public void decodeUtf8Offset() {
     	decodeUtf8Offset(true);
     }
-    
+
     @Test
     public void decodeUtf8OffsetNoArray() {
     	decodeUtf8Offset(false);
     }
-    
+
     private void decodeUtf8Offset2(boolean withArray) {
         byte[] data = new byte[] {8, -61, -65, 0, 1, 2, 4, 8, 16, 32, 64, -62, -128, -61, -128, -61, -65};
-        ByteBuffer in = asReadOnlyIfNeeded(ByteBuffer.wrap(data, /* offset */ 1, data.length-1), withArray);
-        
+        ByteBuffer in = asReadOnlyIfNeeded(ByteBuffer.wrap(data, /* offset */ 1, data.length - 1), withArray);
+
         ByteBuffer out = Encoding.UTF8.decode(in);
-        
+
         ByteBuffer expected = ByteBuffer.wrap(new byte[] {-1, 0, 1, 2, 4, 8, 16, 32, 64, -128, -64, -1});
         assertEquals(expected, out);
     }
@@ -123,22 +123,22 @@ public class EncodingTest {
     public void decodeUtf8Offset2() {
     	decodeUtf8Offset2(true);
     }
-    
+
     @Test
     public void decodeUtf8Offset2NoArray() {
     	decodeUtf8Offset2(false);
     }
-    
+
     private void encodeUtf8EscapeZeroAndNewline(boolean withArray) {
         byte[] bytes = new byte[] {0, 1, 2, 4, 8, 10, 13, 16, 32, 64, 127, -128, -64, -1};
         ByteBuffer in = asReadOnlyIfNeeded(ByteBuffer.wrap(bytes), withArray);
-        
+
         ByteBuffer out = Encoding.UTF8_ESCAPE_ZERO_AND_NEWLINE.encode(in);
-        
+
         ByteBuffer expected = ByteBuffer.wrap(new byte[] {0x7f, 0x30, 1, 2, 4, 8, 0x7f, 0x6e, 0x7f, 0x72, 16, 32, 64, 0x7f, 0x7f, -62, -128, -61, -128, -61, -65});
         assertEquals(expected, out);
     }
-    
+
     @Test
     public void encodeUtf8EscapeZeroAndNewline() {
     	encodeUtf8EscapeZeroAndNewline(true);
@@ -152,13 +152,13 @@ public class EncodingTest {
     private void decodeUtf8EscapeZeroAndNewline(boolean withArray) {
     	byte[] bytes = new byte[] {0x7f, 0x30, 1, 2, 4, 8, 0x7f, 0x6e, 0x7f, 0x72, 16, 32, 64, 0x7f, 0x7f, -62, -128, -61, -128, -61, -65};
         ByteBuffer in = asReadOnlyIfNeeded(ByteBuffer.wrap(bytes), withArray);
-        
+
         ByteBuffer out = Encoding.UTF8_ESCAPE_ZERO_AND_NEWLINE.decode(in);
-        
+
         ByteBuffer expected = ByteBuffer.wrap(new byte[] {0, 1, 2, 4, 8, 10, 13, 16, 32, 64, 127, -128, -64, -1});
         assertEquals(expected, out);
     }
-    
+
     @Test
     public void decodeUtf8EscapeZeroAndNewline() {
     	decodeUtf8EscapeZeroAndNewline(true);
@@ -174,24 +174,24 @@ public class EncodingTest {
         // UTF-8 decode should remove first 2 bit in Byte#2. please refer to http://en.wikipedia.org/wiki/UTF-8.
         byte[] bytes = new byte[] {(byte) 0xc4, (byte) 0x80, (byte) 0xc4, (byte) 0x80, (byte) 0xc2, (byte) 0x80};
         ByteBuffer in = ByteBuffer.wrap(bytes);
-        
+
         ByteBuffer out = Encoding.UTF8.decode(in);
-        
+
         ByteBuffer expected = ByteBuffer.wrap(new byte[] {0, 0, -128});
         assertEquals(expected, out);
     }
-    
+
     private void encodeEscapeZeroAndNewline(boolean withArray) {
     	byte[] bytes = new byte[] {0, 1, 2, 4, 8, 10, 13, 16, 32, 64, 127, -128, -64, -1};
     	ByteBuffer buf = ByteBuffer.wrap(bytes);
     	ByteBuffer in = asReadOnlyIfNeeded(buf, withArray);
-        
+
     	ByteBuffer out = Encoding.ESCAPE_ZERO_AND_NEWLINE.encode(in);
-        
+
     	ByteBuffer expected = ByteBuffer.wrap(new byte[] {0x7f, 0x30, 1, 2, 4, 8, 0x7f, 0x6e, 0x7f, 0x72, 16, 32, 64, 0x7f, 0x7f, -128, -64, -1});
         assertEquals(expected, out);
     }
-    
+
     @Test
     public void encodeEscapeZeroAndNewline() {
     	encodeEscapeZeroAndNewline(true);
@@ -206,13 +206,13 @@ public class EncodingTest {
     	byte[] bytes = new byte[] {0x7f, 0x30, 1, 2, 4, 8, 0x7f, 0x6e, 0x7f, 0x72, 16, 32, 64, 0x7f, 0x7f, -128, -64, -1};
         ByteBuffer buf = ByteBuffer.wrap(bytes);
         ByteBuffer in = asReadOnlyIfNeeded(buf, withArray);
-        
+
         ByteBuffer out = Encoding.ESCAPE_ZERO_AND_NEWLINE.decode(in);
-        
+
         ByteBuffer expected = ByteBuffer.wrap(new byte[] {0, 1, 2, 4, 8, 10, 13, 16, 32, 64, 127, -128, -64, -1});
         assertEquals(expected, out);
     }
-    
+
     @Test
     public void decodeEscapeZeroAndNewline() {
     	decodeEscapeZeroAndNewline(true);
@@ -227,30 +227,30 @@ public class EncodingTest {
 		byte[] bytes = new byte[] {0, 0, 0, 99, 3, 2, 127, 24, 0, 0, 0, 1, 0, 0, 120, 0, 42, 73, 68, 58, 106, 102, 97, 108, 108, 111, 119, 115, 45, 108, 97, 112, 116, 111, 112, 45, 53, 53, 55, 48, 51, 45, 49, 50, 49, 54, 57, 52, 52, 48, 51, 50, 56, 52, 52, 45, 48, 58, 48, 0, 42, 73, 68, 58, 106, 102, 97, 108, 108, 111, 119, 115, 45, 108, 97, 112, 116, 111, 112, 45, 53, 53, 55, 48, 51, 45, 49, 50, 49, 54, 57, 52, 52, 48, 51, 50, 56, 52, 52, 45, 49, 58, 48};
         ByteBuffer buf = ByteBuffer.wrap(bytes);
         ByteBuffer in = asReadOnlyIfNeeded(buf, withArray);
-		
+
 		ByteBuffer out = Encoding.BASE64.encode(in);
-		
+
 		ByteBuffer expected = ByteBuffer.wrap(new byte[] {65, 65, 65, 65, 89, 119, 77, 67, 102, 120, 103, 65, 65, 65, 65, 66, 65, 65, 66, 52, 65, 67, 112, 74, 82, 68, 112, 113, 90, 109, 70, 115, 98, 71, 57, 51, 99, 121, 49, 115, 89, 88, 66, 48, 98, 51, 65, 116, 78, 84, 85, 51, 77, 68, 77, 116, 77, 84, 73, 120, 78, 106, 107, 48, 78, 68, 65, 122, 77, 106, 103, 48, 78, 67, 48, 119, 79, 106, 65, 65, 75, 107, 108, 69, 79, 109, 112, 109, 89, 87, 120, 115, 98, 51, 100, 122, 76, 87, 120, 104, 99, 72, 82, 118, 99, 67, 48, 49, 78, 84, 99, 119, 77, 121, 48, 120, 77, 106, 69, 50, 79, 84, 81, 48, 77, 68, 77, 121, 79, 68, 81, 48, 76, 84, 69, 54, 77, 65, 61, 61});
 		assertEquals(expected, out);
 	}
-	
+
 	@Test
 	public void encodeBase64() {
 		encodeBase64(true);
 	}
-	
+
 	@Test
 	public void encodeBase64NoArray() {
 		encodeBase64(false);
 	}
-	
+
 	private void decodeBase64(boolean withArray) {
 		byte[] bytes = new byte[] {65, 65, 65, 65, 50, 81, 70, 66, 89, 51, 82, 112, 100, 109, 86, 78, 85, 81, 65, 65, 65, 65, 77, 66, 65, 65, 65, 65, 120, 119, 65, 65, 65, 65, 103, 65, 67, 85, 78, 104, 89, 50, 104, 108, 85, 50, 108, 54, 90, 81, 85, 65, 65, 65, 81, 65, 65, 65, 120, 68, 89, 87, 78, 111, 90, 85, 86, 117, 89, 87, 74, 115, 90, 87, 81, 66, 65, 81, 65, 83, 85, 50, 108, 54, 90, 86, 66, 121, 90, 87, 90, 112, 101, 69, 82, 112, 99, 50, 70, 105, 98, 71, 86, 107, 65, 81, 65, 65, 73, 69, 49, 104, 101, 69, 108, 117, 89, 87, 78, 48, 97, 88, 90, 112, 100, 72, 108, 69, 100, 88, 74, 104, 100, 71, 108, 118, 98, 107, 108, 117, 97, 88, 82, 104, 98, 69, 82, 108, 98, 71, 70, 53, 66, 103, 65, 65, 65, 65, 65, 65, 65, 67, 99, 81, 65, 66, 70, 85, 89, 51, 66, 79, 98, 48, 82, 108, 98, 71, 70, 53, 82, 87, 53, 104, 89, 109, 120, 108, 90, 65, 69, 66, 65, 66, 86, 78, 89, 88, 104, 74, 98, 109, 70, 106, 100, 71, 108, 50, 97, 88, 82, 53, 82, 72, 86, 121, 89, 88, 82, 112, 98, 50, 52, 71, 65, 65, 65, 65, 65, 65, 65, 65, 100, 84, 65, 65, 70, 70, 82, 112, 90, 50, 104, 48, 82, 87, 53, 106, 98, 50, 82, 112, 98, 109, 100, 70, 98, 109, 70, 105, 98, 71, 86, 107, 65, 81, 69, 65, 69, 86, 78, 48, 89, 87, 78, 114, 86, 72, 74, 104, 89, 50, 86, 70, 98, 109, 70, 105, 98, 71, 86, 107, 65, 81, 69, 61};
         ByteBuffer buf = ByteBuffer.wrap(bytes);
         ByteBuffer in = asReadOnlyIfNeeded(buf, withArray);
-		
+
 		ByteBuffer out = Encoding.BASE64.decode(in);
-		
+
 		ByteBuffer expected = ByteBuffer.wrap(new byte[] {0, 0, 0, -39, 1, 65, 99, 116, 105, 118, 101, 77, 81, 0, 0, 0, 3, 1, 0, 0, 0, -57, 0, 0, 0, 8, 0, 9, 67, 97, 99, 104, 101, 83, 105, 122, 101, 5, 0, 0, 4, 0, 0, 12, 67, 97, 99, 104, 101, 69, 110, 97, 98, 108, 101, 100, 1, 1, 0, 18, 83, 105, 122, 101, 80, 114, 101, 102, 105, 120, 68, 105, 115, 97, 98, 108, 101, 100, 1, 0, 0, 32, 77, 97, 120, 73, 110, 97, 99, 116, 105, 118, 105, 116, 121, 68, 117, 114, 97, 116, 105, 111, 110, 73, 110, 105, 116, 97, 108, 68, 101, 108, 97, 121, 6, 0, 0, 0, 0, 0, 0, 39, 16, 0, 17, 84, 99, 112, 78, 111, 68, 101, 108, 97, 121, 69, 110, 97, 98, 108, 101, 100, 1, 1, 0, 21, 77, 97, 120, 73, 110, 97, 99, 116, 105, 118, 105, 116, 121, 68, 117, 114, 97, 116, 105, 111, 110, 6, 0, 0, 0, 0, 0, 0, 117, 48, 0, 20, 84, 105, 103, 104, 116, 69, 110, 99, 111, 100, 105, 110, 103, 69, 110, 97, 98, 108, 101, 100, 1, 1, 0, 17, 83, 116, 97, 99, 107, 84, 114, 97, 99, 101, 69, 110, 97, 98, 108, 101, 100, 1, 1});
 
 		assertEquals(expected, out);
@@ -286,10 +286,10 @@ public class EncodingTest {
         fragmentedSequence("C2", "A9313131", Encoding.UTF8_ESCAPE_ZERO_AND_NEWLINE, false);
     }
 
-    // Our UTF8 decoding does not currently handle more than 2 byte characters, because the client never 
+    // Our UTF8 decoding does not currently handle more than 2 byte characters, because the client never
     // uses more than 2 byte characters (because it only needs to encode byte values up to 255)
     // so we don't need to test 3 byte characters like E2A480 nor 4 byters like F0908080
-    
+
 
     @Test
     public void fragmentsSplitWithin2ByteEscapedNewlineUTF8Escape() throws Exception {
@@ -306,13 +306,13 @@ public class EncodingTest {
         // Present [013030C3BF30] as one fragment.
         decodeSinglePacket("013030C3BF30", "013030FF30", Encoding.UTF8, true);
     }
-    
+
     @Test
     public void singleEndingWithASCIICharacterUTF8NoArray() throws Exception {
         // Present [013030C3BF30] as one fragment.
         decodeSinglePacket("013030C3BF30", "013030FF30", Encoding.UTF8, false);
     }
-    
+
     @Test
     public void singleEndingWith2ByteCharacterUTF8() throws Exception {
         // Present [013030C3BF] as one fragment.
@@ -331,7 +331,7 @@ public class EncodingTest {
         final ByteBuffer fragment2 = asReadOnlyIfNeeded(ByteBuffer.wrap(Utils.fromHex(fragment2Str)), withArray);
         final Object[] remainingByteState = new Object[1];
         final byte remainingByte = fragment1.get(fragment1.remaining()-1);
-        
+
         Mockery context = new Mockery();
         final DecodingState state = context.mock(DecodingState.class);
         context.checking(new Expectations() {
@@ -364,7 +364,7 @@ public class EncodingTest {
         assertFalse(result.hasRemaining());
 
         context.assertIsSatisfied();
-        
+
         //context = new Mockery();
         //DecodingState state = context.mock(DecodingState.class);
 
@@ -375,10 +375,10 @@ public class EncodingTest {
                     will(returnValue(remainingByteState[0]));
 
                     oneOf(state).set(null);
-                    
+
                     oneOf(state).get();
                     will(returnValue(null));
-                    
+
                     oneOf(state).set(null);
                 } catch (Exception e) {
                     throw new RuntimeException(e);
@@ -417,7 +417,7 @@ public class EncodingTest {
         byte[] byteArray = Utils.fromHex(payload);
         ByteBuffer buffer = asReadOnlyIfNeeded(ByteBuffer.wrap(byteArray), withArray);
         ByteBuffer result = encoding.decode(buffer, state);
-        
+
         // equals does not check via array or check for readonly flag/direct buffers
         Assert.assertEquals(ByteBuffer.wrap(Utils.fromHex(expectedResult)), result);
         context.assertIsSatisfied();
@@ -425,7 +425,7 @@ public class EncodingTest {
 
     public static void main(String... args) throws Exception {
 		int count = 1000 * 1000;
-		
+
 		byte[] decoded = new byte[] {0, 0, 0, 99, 3, 2, 127, 24, 0, 0, 0, 1, 0, 0, 120, 0, 42, 73, 68, 58, 106, 102, 97, 108, 108, 111, 119, 115, 45, 108, 97, 112, 116, 111, 112, 45, 53, 53, 55, 48, 51, 45, 49, 50, 49, 54, 57, 52, 52, 48, 51, 50, 56, 52, 52, 45, 48, 58, 48, 0, 42, 73, 68, 58, 106, 102, 97, 108, 108, 111, 119, 115, 45, 108, 97, 112, 116, 111, 112, 45, 53, 53, 55, 48, 51, 45, 49, 50, 49, 54, 57, 52, 52, 48, 51, 50, 56, 52, 52, 45, 49, 58, 48};
 		byte[] encoded = new byte[] {65, 65, 65, 65, 50, 81, 70, 66, 89, 51, 82, 112, 100, 109, 86, 78, 85, 81, 65, 65, 65, 65, 77, 66, 65, 65, 65, 65, 120, 119, 65, 65, 65, 65, 103, 65, 67, 85, 78, 104, 89, 50, 104, 108, 85, 50, 108, 54, 90, 81, 85, 65, 65, 65, 81, 65, 65, 65, 120, 68, 89, 87, 78, 111, 90, 85, 86, 117, 89, 87, 74, 115, 90, 87, 81, 66, 65, 81, 65, 83, 85, 50, 108, 54, 90, 86, 66, 121, 90, 87, 90, 112, 101, 69, 82, 112, 99, 50, 70, 105, 98, 71, 86, 107, 65, 81, 65, 65, 73, 69, 49, 104, 101, 69, 108, 117, 89, 87, 78, 48, 97, 88, 90, 112, 100, 72, 108, 69, 100, 88, 74, 104, 100, 71, 108, 118, 98, 107, 108, 117, 97, 88, 82, 104, 98, 69, 82, 108, 98, 71, 70, 53, 66, 103, 65, 65, 65, 65, 65, 65, 65, 67, 99, 81, 65, 66, 70, 85, 89, 51, 66, 79, 98, 48, 82, 108, 98, 71, 70, 53, 82, 87, 53, 104, 89, 109, 120, 108, 90, 65, 69, 66, 65, 66, 86, 78, 89, 88, 104, 74, 98, 109, 70, 106, 100, 71, 108, 50, 97, 88, 82, 53, 82, 72, 86, 121, 89, 88, 82, 112, 98, 50, 52, 71, 65, 65, 65, 65, 65, 65, 65, 65, 100, 84, 65, 65, 70, 70, 82, 112, 90, 50, 104, 48, 82, 87, 53, 106, 98, 50, 82, 112, 98, 109, 100, 70, 98, 109, 70, 105, 98, 71, 86, 107, 65, 81, 69, 65, 69, 86, 78, 48, 89, 87, 78, 114, 86, 72, 74, 104, 89, 50, 86, 70, 98, 109, 70, 105, 98, 71, 86, 107, 65, 81, 69, 61};
 
@@ -435,14 +435,14 @@ public class EncodingTest {
 			testEncodePerformance(decodedBuf, count);
 			testDecodePerformance(encodedBuf, count);
 		}
-		
+
 		// Repeat using direct buffers
 		{
 		    ByteBuffer decodedBuf = ByteBuffer.allocateDirect(decoded.length);
 			decodedBuf.put(decoded);
 			decodedBuf.flip();
 			testEncodePerformance(decodedBuf, count);
-			
+
             ByteBuffer encodedBuf = ByteBuffer.allocateDirect(encoded.length);
 			encodedBuf.put(encoded);
 			encodedBuf.flip();
@@ -469,7 +469,7 @@ public class EncodingTest {
 			Encoding.BASE64.decode(in.duplicate());
 		}
 		long endAt = System.currentTimeMillis();
-		
+
 		int decodedBytes = count * in.remaining();
 		long decodedMillis = (endAt - startAt);
 		float decodedMegabytesPerSecond = (decodedBytes / (1024.0f * 1024.0f)) / (decodedMillis / 1000.0f);

--- a/src/test/java/org/kaazing/gateway/util/UtilsTest.java
+++ b/src/test/java/org/kaazing/gateway/util/UtilsTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -45,7 +45,7 @@ public class UtilsTest {
         public static int INT_FIELD = 11;
     }
     private static String NON_ASCII_UTF8_STRING = "\u6C34"; // CJK UNIFIED IDEOGRAPH-6C34 (water)
-    
+
 
 
     @Test
@@ -99,7 +99,7 @@ public class UtilsTest {
         String result = Utils.asString(in);
         assertEquals(NON_ASCII_UTF8_STRING.charAt(0), result.charAt(0));
     }
-    
+
     @Test
     public void getIntShouldWorkBigEndianIndex0() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(4);
@@ -110,7 +110,7 @@ public class UtilsTest {
         int expected = buf.getInt();
         assertEquals(expected, result);
     }
-    
+
     @Test
     public void getIntShouldWorkLittleEndianIndex0() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(4);
@@ -121,7 +121,7 @@ public class UtilsTest {
         int expected = buf.getInt();
         assertEquals(expected, result);
     }
-    
+
     @Test
     public void getIntShouldWorkBigEndianIndexNonZero() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(8);
@@ -132,7 +132,7 @@ public class UtilsTest {
         int result = Utils.getInt(buf, 4);
         assertEquals(87654321, result);
     }
-    
+
     @Test
     public void getIntShouldWorkLittleEndianIndexNonZero() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(8);
@@ -143,21 +143,21 @@ public class UtilsTest {
         int result = Utils.getInt(buf, 4);
         assertEquals(87654321, result);
     }
-    
+
     @Test(expected=IndexOutOfBoundsException.class)
     public void getIntShouldFailIfLimitTooLowBigEndian() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(3);
         buf.order(BIG_ENDIAN);
         Utils.getInt(buf, 0);
     }
-    
+
     @Test(expected=IndexOutOfBoundsException.class)
     public void getIntShouldFailIfLimitTooLowLittleEndianIndex() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(3);
         buf.order(LITTLE_ENDIAN);
         Utils.getInt(buf, 0);
     }
-    
+
     @Test
     public void getLongShouldWorkBigEndianIndex0() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(8);
@@ -168,7 +168,7 @@ public class UtilsTest {
         long expected = buf.getLong();
         assertEquals(expected, result);
     }
-    
+
     @Test
     public void getLongShouldWorkLittleEndianIndex0() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(8);
@@ -179,7 +179,7 @@ public class UtilsTest {
         long expected = buf.getLong();
         assertEquals(expected, result);
     }
-    
+
     @Test
     public void getLongShouldWorkBigEndianIndexNonZero() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(16);
@@ -190,7 +190,7 @@ public class UtilsTest {
         long result = Utils.getLong(buf, 8);
         assertEquals(876543210987654321L, result);
     }
-    
+
     @Test
     public void getLongShouldWorkLittleEndianIndexNonZero() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(16);
@@ -201,21 +201,21 @@ public class UtilsTest {
         long result = Utils.getLong(buf, 8);
         assertEquals(876543210987654321L, result);
     }
-    
+
     @Test(expected=IndexOutOfBoundsException.class)
     public void getLongShouldFailIfLimitTooLowBigEndian() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(8);
         buf.order(BIG_ENDIAN);
         Utils.getLong(buf, 1);
     }
-    
+
     @Test(expected=IndexOutOfBoundsException.class)
     public void getLongShouldFailIfLimitTooLowLittleEndianIndex() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(8);
         buf.order(LITTLE_ENDIAN);
         Utils.getLong(buf, 1);
     }
-    
+
     @Test
     public void getShortShouldWorkBigEndianIndex0() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(4);
@@ -226,7 +226,7 @@ public class UtilsTest {
         short expected = buf.getShort();
         assertEquals(expected, result);
     }
-    
+
     @Test
     public void getShortShouldWorkLittleEndianIndex0() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(4);
@@ -237,7 +237,7 @@ public class UtilsTest {
         short expected = buf.getShort();
         assertEquals(expected, result);
     }
-    
+
     @Test
     public void getShortShouldWorkBigEndianIndexNonZero() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(4);
@@ -248,7 +248,7 @@ public class UtilsTest {
         short result = Utils.getShort(buf, 2);
         assertEquals(32101, result);
     }
-    
+
     @Test
     public void getShortShouldWorkLittleEndianIndexNonZero() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(4);
@@ -259,14 +259,14 @@ public class UtilsTest {
         short result = Utils.getShort(buf, 2);
         assertEquals(32101, result);
     }
-    
+
     @Test(expected=IndexOutOfBoundsException.class)
     public void getShortShouldFailIfLimitTooLowBigEndian() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(3);
         buf.order(BIG_ENDIAN);
         Utils.getShort(buf, 2);
     }
-    
+
     @Test(expected=IndexOutOfBoundsException.class)
     public void getShortShouldFailIfLimitTooLowLittleEndianIndex() throws Exception {
         ByteBuffer buf = ByteBuffer.allocate(3);
@@ -336,19 +336,19 @@ public class UtilsTest {
     @Test
     public void kilobytesLC() {
         int result = Utils.parseDataSize("12345k");
-        assertEquals(12345*1024, result);
+        assertEquals(12345 * 1024, result);
     }
 
     @Test
     public void kilobytesUC() {
         int result = Utils.parseDataSize("12345K");
-        assertEquals(12345*1024, result);
+        assertEquals(12345 * 1024, result);
     }
 
     @Test
     public void megabytesLC() {
         int result = Utils.parseDataSize("1m");
-        assertEquals(1*1024*1024, result);
+        assertEquals(1 * 1024 * 1024, result);
     }
 
     @Test
@@ -392,25 +392,25 @@ public class UtilsTest {
     @Test
     public void kilobytesDataRate() {
         long result = Utils.parseDataRate("12345kB/s");
-        assertEquals(12345*1000, result);
+        assertEquals(12345 * 1000, result);
     }
 
     @Test
     public void kibibytesDataRate() {
         long result = Utils.parseDataRate("12345KiB/s");
-        assertEquals(12345*1024, result);
+        assertEquals(12345 * 1024, result);
     }
 
     @Test
     public void megabytesDataRate() {
         long result = Utils.parseDataRate("1MB/s");
-        assertEquals(1*1000*1000, result);
+        assertEquals(1 * 1000 * 1000, result);
     }
 
     @Test
     public void mibibytesDataRate() {
         long result = Utils.parseDataRate("100MiB/s");
-        assertEquals(100*1024*1024, result);
+        assertEquals(100 * 1024 * 1024, result);
     }
 
     @Test (expected=NumberFormatException.class)

--- a/src/test/java/org/kaazing/gateway/util/asn1/Asn1UtilsTest.java
+++ b/src/test/java/org/kaazing/gateway/util/asn1/Asn1UtilsTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -75,7 +75,7 @@ public class Asn1UtilsTest {
     @Test
     public void testEncodeIntegerZero() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[3]);
-        buf.position(buf.position()+3);
+        buf.position(buf.position() + 3);
         int len = Asn1Utils.encodeInteger(0, buf);
         assertEquals(3, len);
         assertEquals(0, buf.position());
@@ -87,7 +87,7 @@ public class Asn1UtilsTest {
     @Test
     public void testEncodeInteger1Byte() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[3]);
-        buf.position(buf.position()+3);
+        buf.position(buf.position() + 3);
         int len = Asn1Utils.encodeInteger(15, buf);
         assertEquals(3, len);
         assertEquals(0, buf.position());
@@ -99,7 +99,7 @@ public class Asn1UtilsTest {
     @Test
     public void testEncodeInteger2Byte() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[4]);
-        buf.position(buf.position()+4);
+        buf.position(buf.position() + 4);
         int len = Asn1Utils.encodeInteger(512, buf);
         assertEquals(4, len);
         assertEquals(0, buf.position());
@@ -153,7 +153,7 @@ public class Asn1UtilsTest {
     @Test
     public void testEncodeSequence() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[4]);
-        buf.position(buf.position()+2);
+        buf.position(buf.position() + 2);
         int len = Asn1Utils.encodeSequence(2, buf);
         assertEquals(4, len);
         assertEquals(0, buf.position());
@@ -223,7 +223,7 @@ public class Asn1UtilsTest {
     @Test
     public void testEncodeBitString8() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[4]);
-        buf.position(buf.position()+4);
+        buf.position(buf.position() + 4);
         BitSet bits = new BitSet(8);
         bits.set(3);
         bits.set(5);
@@ -239,7 +239,7 @@ public class Asn1UtilsTest {
     @Test
     public void testEncodeBitString32() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[7]);
-        buf.position(buf.position()+7);
+        buf.position(buf.position() + 7);
         BitSet bits = new BitSet(32);
         bits.set(8);
         int len = Asn1Utils.encodeBitString(bits, 32, buf);
@@ -257,7 +257,7 @@ public class Asn1UtilsTest {
     @Test(expected = IllegalArgumentException.class)
     public void testEncodeBitString32As8() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[7]);
-        buf.position(buf.position()+7);
+        buf.position(buf.position() + 7);
         BitSet bits = new BitSet(32);
         bits.set(8);
         Asn1Utils.encodeBitString(bits, 8, buf);
@@ -316,7 +316,7 @@ public class Asn1UtilsTest {
     @Test
     public void testEncodeIA5StringWithNull() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[2]);
-        buf.position(buf.position()+2);
+        buf.position(buf.position() + 2);
         int len = Asn1Utils.encodeIA5String(null, buf);
         assertEquals(2, len);
         assertEquals(0, buf.position());
@@ -327,7 +327,7 @@ public class Asn1UtilsTest {
     @Test
     public void testEncodeIA5StringWithEmpty() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[2]);
-        buf.position(buf.position()+2);
+        buf.position(buf.position() + 2);
         int len = Asn1Utils.encodeIA5String("", buf);
         assertEquals(2, len);
         assertEquals(0, buf.position());
@@ -338,7 +338,7 @@ public class Asn1UtilsTest {
     @Test
     public void testEncodeIA5StringWithValue() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[6]);
-        buf.position(buf.position()+6);
+        buf.position(buf.position() + 6);
         int len = Asn1Utils.encodeIA5String("arun", buf);
         assertEquals(6, len);
         assertEquals(0, buf.position());
@@ -625,7 +625,7 @@ public class Asn1UtilsTest {
 
         int size = 17;
         ByteBuffer buf = ByteBuffer.wrap(new byte[size]);
-        buf.position(buf.position()+size);
+        buf.position(buf.position() + size);
         int len = Asn1Utils.encodeGeneralizedTime(date, buf);
 
         assertEquals(size, len);
@@ -663,7 +663,7 @@ public class Asn1UtilsTest {
         Date date = cal.getTime();
         assertEquals(17, Asn1Utils.sizeOfGeneralizedTime(date));
     }
-    
+
     @Test
     public void testSizeOfGeneralizedTimeWithFracSet() {
         Calendar cal = Calendar.getInstance();
@@ -679,7 +679,7 @@ public class Asn1UtilsTest {
         Date date = cal.getTime();
         assertEquals(17, Asn1Utils.sizeOfGeneralizedTime(date));
     }
-    
+
     // ----- END: GeneralizedTime tests
 
     // ----- BEGIN: OCTET STRING tests
@@ -728,7 +728,7 @@ public class Asn1UtilsTest {
     @Test
     public void testEncodeOctetStringNull() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[2]);
-        buf.position(buf.position()+2);
+        buf.position(buf.position() + 2);
         int len = Asn1Utils.encodeOctetString(null, buf);
         assertEquals(2, len);
         assertEquals(0, buf.position());
@@ -739,7 +739,7 @@ public class Asn1UtilsTest {
     @Test
     public void testEncodeOctetStringEmpty() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[2]);
-        buf.position(buf.position()+2);
+        buf.position(buf.position() + 2);
         int len = Asn1Utils.encodeOctetString(new short[] {}, buf);
         assertEquals(2, len);
         assertEquals(0, buf.position());
@@ -750,7 +750,7 @@ public class Asn1UtilsTest {
     @Test
     public void testEncodeOctetString() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[6]);
-        buf.position(buf.position()+6);
+        buf.position(buf.position() + 6);
         int len = Asn1Utils.encodeOctetString(new short[] { 192, 168, 0, 15 }, buf);
         assertEquals(6, len);
         assertEquals(0, buf.position());

--- a/src/test/java/org/kaazing/gateway/util/der/DerIdTest.java
+++ b/src/test/java/org/kaazing/gateway/util/der/DerIdTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/src/test/java/org/kaazing/gateway/util/der/DerUtilsTest.java
+++ b/src/test/java/org/kaazing/gateway/util/der/DerUtilsTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -92,14 +92,14 @@ public class DerUtilsTest {
     @Test(expected = IllegalArgumentException.class)
     public void testEncodeIllegalTagNumber() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[12]);
-        buf.position(buf.position()+2);
+        buf.position(buf.position() + 2);
         DerUtils.encodeIdAndLength(DerId.TagClass.UNIVERSAL, DerId.EncodingType.PRIMITIVE, -1, 10, buf);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testEncodeIllegalLength() {
         ByteBuffer buf = ByteBuffer.wrap(new byte[12]);
-        buf.position(buf.position()+2);
+        buf.position(buf.position() + 2);
         DerUtils.encodeIdAndLength(DerId.TagClass.UNIVERSAL, DerId.EncodingType.PRIMITIVE, 2, -10, buf);
     }
 
@@ -107,7 +107,7 @@ public class DerUtilsTest {
     public void testEncode1() {
         // universal, primitive, tag <= 30, short length
         ByteBuffer buf = ByteBuffer.wrap(new byte[12]);
-        buf.position(buf.position()+2);
+        buf.position(buf.position() + 2);
         int len = DerUtils.encodeIdAndLength(DerId.TagClass.UNIVERSAL, DerId.EncodingType.PRIMITIVE, 2, 10, buf);
         assertEquals(2, len);
         assertEquals(0, buf.position());
@@ -119,7 +119,7 @@ public class DerUtilsTest {
     public void testEncode2() {
         // application, primitive, tag <= 30, short length
         ByteBuffer buf = ByteBuffer.wrap(new byte[12]);
-        buf.position(buf.position()+2);
+        buf.position(buf.position() + 2);
         int len = DerUtils.encodeIdAndLength(DerId.TagClass.APPLICATION, DerId.EncodingType.PRIMITIVE, 2, 10, buf);
         assertEquals(2, len);
         assertEquals(0, buf.position());
@@ -131,7 +131,7 @@ public class DerUtilsTest {
     public void testEncode3() {
         // context specific, constructed, tag <= 30, short length
         ByteBuffer buf = ByteBuffer.wrap(new byte[12]);
-        buf.position(buf.position()+2);
+        buf.position(buf.position() + 2);
         int len = DerUtils.encodeIdAndLength(DerId.TagClass.CONTEXT_SPECIFIC, DerId.EncodingType.CONSTRUCTED, 2, 10, buf);
         assertEquals(2, len);
         assertEquals(0, buf.position());
@@ -143,7 +143,7 @@ public class DerUtilsTest {
     public void testEncode4() {
         // private, constructed, tag <= 30, short length
         ByteBuffer buf = ByteBuffer.wrap(new byte[12]);
-        buf.position(buf.position()+2);
+        buf.position(buf.position() + 2);
         int len = DerUtils.encodeIdAndLength(DerId.TagClass.PRIVATE, DerId.EncodingType.CONSTRUCTED, 2, 10, buf);
         assertEquals(2, len);
         assertEquals(0, buf.position());
@@ -155,7 +155,7 @@ public class DerUtilsTest {
     public void testEncode5() {
         // universal, primitive, tag > 30 (2 byte), short length
         ByteBuffer buf = ByteBuffer.wrap(new byte[13]);
-        buf.position(buf.position()+3);
+        buf.position(buf.position() + 3);
         int len = DerUtils.encodeIdAndLength(DerId.TagClass.UNIVERSAL, DerId.EncodingType.PRIMITIVE, 32, 10, buf);
         assertEquals(3, len);
         assertEquals(0, buf.position());
@@ -168,7 +168,7 @@ public class DerUtilsTest {
     public void testEncode6() {
         // application, primitive, tag > 30 (2 byte), short length
         ByteBuffer buf = ByteBuffer.wrap(new byte[13]);
-        buf.position(buf.position()+3);
+        buf.position(buf.position() + 3);
         int len = DerUtils.encodeIdAndLength(DerId.TagClass.APPLICATION, DerId.EncodingType.PRIMITIVE, 32, 10, buf);
         assertEquals(3, len);
         assertEquals(0, buf.position());
@@ -181,7 +181,7 @@ public class DerUtilsTest {
     public void testEncode7() {
         // context specific, constructed, tag > 30 (2 byte), short length
         ByteBuffer buf = ByteBuffer.wrap(new byte[13]);
-        buf.position(buf.position()+3);
+        buf.position(buf.position() + 3);
         int len = DerUtils.encodeIdAndLength(DerId.TagClass.CONTEXT_SPECIFIC, DerId.EncodingType.CONSTRUCTED, 32, 10, buf);
         assertEquals(3, len);
         assertEquals(0, buf.position());
@@ -194,7 +194,7 @@ public class DerUtilsTest {
     public void testEncode8() {
         // private, constructed, tag > 30 (2 byte), short length
         ByteBuffer buf = ByteBuffer.wrap(new byte[13]);
-        buf.position(buf.position()+3);
+        buf.position(buf.position() + 3);
         int len = DerUtils.encodeIdAndLength(DerId.TagClass.PRIVATE, DerId.EncodingType.CONSTRUCTED, 32, 10, buf);
         assertEquals(3, len);
         assertEquals(0, buf.position());
@@ -207,7 +207,7 @@ public class DerUtilsTest {
     public void testEncode9() {
         // context specific, constructed, tag > 30 (3 byte), short length
         ByteBuffer buf = ByteBuffer.wrap(new byte[14]);
-        buf.position(buf.position()+4);
+        buf.position(buf.position() + 4);
         int len = DerUtils.encodeIdAndLength(DerId.TagClass.CONTEXT_SPECIFIC, DerId.EncodingType.CONSTRUCTED, 53280, 10, buf);
         assertEquals(4, len);
         assertEquals(0, buf.position());
@@ -221,7 +221,7 @@ public class DerUtilsTest {
     public void testEncode10() {
         // context specific, constructed, tag > 30 (3 byte), long length (201)
         ByteBuffer buf = ByteBuffer.wrap(new byte[206]);
-        buf.position(buf.position()+5);
+        buf.position(buf.position() + 5);
         int len = DerUtils.encodeIdAndLength(DerId.TagClass.CONTEXT_SPECIFIC, DerId.EncodingType.CONSTRUCTED, 53280, 201, buf);
         assertEquals(5, len);
         assertEquals(0, buf.position());

--- a/src/test/java/org/kaazing/gateway/util/parse/ConfigParameterTest.java
+++ b/src/test/java/org/kaazing/gateway/util/parse/ConfigParameterTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -158,7 +158,7 @@ public class ConfigParameterTest {
         testResolveAndReplaceParameter("$$${" + parameters.keySet().toArray()[0] + "}", "$${"
                 + parameters.keySet().toArray()[0] + "}", "", "", false);
     }
-    
+
 	@Test
 	public void testResolveAttemptToGetCloudHostname() {
 		final String resultUrl = "ec2-54-176-0-142.us-west-1.compute.amazonaws.com";
@@ -215,7 +215,7 @@ public class ConfigParameterTest {
 		});
 		assertTrue(result == null);
 	}
-	
+
 	@Test
 	public void testResolveAttemptToGetInstanceId() {
 		final String resultId = "i-5325f23";

--- a/src/test/java/org/kaazing/gateway/util/ssl/SslCipherSuitesTest.java
+++ b/src/test/java/org/kaazing/gateway/util/ssl/SslCipherSuitesTest.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2007-2014 Kaazing Corporation. All rights reserved.
- * 
+ *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -8,9 +8,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY


### PR DESCRIPTION
even with a few helper perl scripts this was painful.  I've very carefully reviewed for accidental semantic changes, and if someone else would like to run their eyes past it I've no objections
* codestyle checks pass, integrated with code.quality module in the pom.xml
* incorporated uses of the diamond operator <> for Java 7